### PR TITLE
Added BindIP, so that cluster can be bound to a specific IP

### DIFF
--- a/client-programs/educates/pkg/cluster/kindclusterconfig.yaml.tpl
+++ b/client-programs/educates/pkg/cluster/kindclusterconfig.yaml.tpl
@@ -19,9 +19,15 @@ nodes:
   {{- end }}
   extraPortMappings:
   - containerPort: 80
+    {{- if .BindIP }}
+    listenAddress: {{ .BindIP }}
+    {{- end }}
     hostPort: 80
     protocol: TCP
   - containerPort: 443
+    {{- if .BindIP }}
+    listenAddress: {{ .BindIP }}
+    {{- end }}
     hostPort: 443
     protocol: TCP
 containerdConfigPatches:

--- a/client-programs/educates/pkg/config/installationconfig.go
+++ b/client-programs/educates/pkg/config/installationconfig.go
@@ -164,6 +164,7 @@ type TrainingPlatformConfig struct {
 }
 
 type InstallationConfig struct {
+	BindIP                string                      `yaml:"bindIP,omitempty"`
 	ClusterInfrastructure ClusterInfrastructureConfig `yaml:"clusterInfrastructure,omitempty"`
 	ClusterPackages       ClusterPackagesConfig       `yaml:"clusterPackages,omitempty"`
 	ClusterSecurity       ClusterSecurityConfig       `yaml:"clusterSecurity,omitempty"`


### PR DESCRIPTION
@GrahamDumpleton This adds a bindIP, so that you can specify in config to which IP the cluster will be bound. This IP will be used to detect port collision as well as to bind ports 80 and 443 in the generated cluster, but only if explicitly specified in the config. No autodetection of the bindIP