### PR TITLE
allow workshop sessions to be terminated

### DIFF
--- a/training-portal/src/project/apps/workshops/urls.py
+++ b/training-portal/src/project/apps/workshops/urls.py
@@ -10,7 +10,8 @@ urlpatterns = [
         views.catalog_environments,
         name="workshops_catalog_environments",
     ),
-    path("environment/<slug:name>/", views.environment, name="workshops_environment"),
+    path("environment/<slug:name>/", views.environment,
+         name="workshops_environment"),
     path(
         "environment/<slug:name>/create/",
         views.environment_create,
@@ -46,6 +47,11 @@ urlpatterns = [
         "session/<slug:name>/extend/",
         views.session_extend,
         name="workshops_session_extend",
+    ),
+    path(
+        "session/<slug:name>/terminate/",
+        views.session_terminate,
+        name="workshops_session_terminate",
     ),
     path(
         "session/<slug:name>/event/",


### PR DESCRIPTION
This PR adds a new API endpoint at `{training-portal}/workshops/session/{name}/terminate` that permits a workshop session to be terminated by a robot or staff user.

Signed-off-by: Joe Fitzgerald <jfitzgerald@vmware.com>