### PR TITLE
Change default capacity limits for portal/workshops when using CLI.

### DIFF
--- a/client-programs/pkg/cmd/cluster_portal_create_cmd.go
+++ b/client-programs/pkg/cmd/cluster_portal_create_cmd.go
@@ -79,7 +79,7 @@ func (p *ProjectInfo) NewClusterPortalCreateCmd() *cobra.Command {
 	c.Flags().UintVar(
 		&o.Capacity,
 		"capacity",
-		1,
+		5,
 		"maximum number of current sessions for the training portal",
 	)
 	c.Flags().StringVar(

--- a/client-programs/pkg/cmd/cluster_workshop_deploy_cmd.go
+++ b/client-programs/pkg/cmd/cluster_workshop_deploy_cmd.go
@@ -135,8 +135,8 @@ func (p *ProjectInfo) NewClusterWorkshopDeployCmd() *cobra.Command {
 	c.Flags().UintVar(
 		&o.Capacity,
 		"capacity",
-		1,
-		"maximum number of current sessions for the workshop",
+		0,
+		"maximum number of concurrent sessions for this workshop",
 	)
 	c.Flags().UintVar(
 		&o.Reserved,
@@ -292,7 +292,7 @@ func deployWorkshopResource(client dynamic.Interface, workshop *unstructured.Uns
 					"sessions": struct {
 						Maximum int64 `json:"maximum"`
 					}{
-						Maximum: 1,
+						Maximum: 5,
 					},
 					"workshop": map[string]interface{}{
 						"defaults": struct {


### PR DESCRIPTION
Addresses https://github.com/vmware-tanzu-labs/educates-training-platform/issues/93