### PR TITLE
Set platform architecture variable when deploying workshop to local docker.

### DIFF
--- a/client-programs/pkg/cmd/docker_workshop_deploy_cmd.go
+++ b/client-programs/pkg/cmd/docker_workshop_deploy_cmd.go
@@ -650,6 +650,7 @@ func generateVendirFilesConfig(workshop *unstructured.Unstructured, name string,
 			vendirConfigString = strings.ReplaceAll(vendirConfigString, "$(image_repository)", repository)
 			vendirConfigString = strings.ReplaceAll(vendirConfigString, "$(workshop_name)", name)
 			vendirConfigString = strings.ReplaceAll(vendirConfigString, "$(workshop_version)", workshopVersion)
+			vendirConfigString = strings.ReplaceAll(vendirConfigString, "$(platform_arch)", runtime.GOARCH)
 
 			vendirConfigs = append(vendirConfigs, vendirConfigString)
 		}


### PR DESCRIPTION
Fixes: https://github.com/vmware-tanzu-labs/educates-training-platform/issues/105