### PR TITLE
Ensure local config directory is created if doesn't exist.

### DIFF
--- a/client-programs/pkg/cmd/cluster_workshop_serve_cmd.go
+++ b/client-programs/pkg/cmd/cluster_workshop_serve_cmd.go
@@ -80,6 +80,12 @@ func generateAccessToken(refresh bool) (string, error) {
 	configFileDir := path.Join(xdg.DataHome, "educates")
 	accessTokenFile := path.Join(configFileDir, "live-reload-token.dat")
 
+	err := os.MkdirAll(configFileDir, os.ModePerm)
+
+	if err != nil {
+		return "", errors.Wrapf(err, "unable to create config directory")
+	}
+
 	var accessToken string
 
 	if refresh {


### PR DESCRIPTION
Fixes: https://github.com/vmware-tanzu-labs/educates-training-platform/issues/110