### PR TITLE
Allow image puller to be disabled by setting image list to empty.

### DIFF
--- a/carvel-packages/training-platform/bundle/config/11-session-manager/07-daemonsets.yaml
+++ b/carvel-packages/training-platform/bundle/config/11-session-manager/07-daemonsets.yaml
@@ -1,8 +1,11 @@
 #@ load("@ytt:data", "data")
 #@ load("/00-package.star", "image_reference", "image_pull_secrets", "image_pull_policy")
 
-#@ prepull = ["training-portal"]
+#@ prepull = []
+#@ if data.values.imagePuller.prePullImages:
+#@ prepull.append("training-portal")
 #@ prepull.extend(data.values.imagePuller.prePullImages)
+#@ end
 
 ---
 #@ if prepull:


### PR DESCRIPTION
Fixes: https://github.com/vmware-tanzu-labs/educates-training-platform/issues/108