### PR TITLE
Missing finalizers RBAC required for OpenShift.

### DIFF
--- a/carvel-packages/training-platform/bundle/config/11-session-manager/01-clusterroles.yaml
+++ b/carvel-packages/training-platform/bundle/config/11-session-manager/01-clusterroles.yaml
@@ -686,6 +686,7 @@ rules:
     resources:
       - trainingportals/finalizers
       - workshopenvironments/finalizers
+      - workshopsessions/finalizers
     verbs:
       - update
   - apiGroups:


### PR DESCRIPTION
Fixes: https://github.com/vmware-tanzu-labs/educates-training-platform/issues/122