### PR TITLE
Change default loopback hostname so uses cluster domain variable.

### DIFF
--- a/client-programs/pkg/cmd/cluster_workshop_serve_cmd.go
+++ b/client-programs/pkg/cmd/cluster_workshop_serve_cmd.go
@@ -275,7 +275,7 @@ func (p *ProjectInfo) NewClusterWorkshopServeCmd() *cobra.Command {
 	c.Flags().StringVar(
 		&o.ProxyHost,
 		"proxy-host",
-		"loopback.default.svc.cluster.local",
+		"loopback.default.svc.$(cluster_domain)",
 		"host by which any remote proxy will be accessed",
 	)
 	c.Flags().IntVar(


### PR DESCRIPTION
Fixes: https://github.com/vmware-tanzu-labs/educates-training-platform/issues/121