### PR TITLE
rename "Open Workshop" to "Open Instructions"

### DIFF
--- a/workshop-images/base-environment/opt/gateway/src/backend/views/workarea-panel-content.pug
+++ b/workshop-images/base-environment/opt/gateway/src/backend/views/workarea-panel-content.pug
@@ -35,7 +35,7 @@ div#workarea-content
 
                     div.dropdown-menu.dropdown-menu-right
                         if config.enable_workshop
-                            a.btn.dropdown-item.open-window(role="menuitem", data-url="/workshop/") Open Workshop
+                            a.btn.dropdown-item.open-window(role="menuitem", data-url="/workshop/") Open Instructions
 
                         if config.enable_terminal
                             a.btn.dropdown-item.open-window(role="menuitem", data-url="/terminal/session/") Open Terminal


### PR DESCRIPTION
Rename the hamburger item from `Workshop` to `Instructions` to provide a better and more clear user experience. See #223 