### PR TITLE
Allow $HOME/ reference in editor clickable actions.

### DIFF
--- a/project-docs/getting-started/creating-a-workshop.md
+++ b/project-docs/getting-started/creating-a-workshop.md
@@ -115,7 +115,7 @@ When such an ``exercises`` sub directory exists, the initial working directory f
 
 Note that the ``exercises`` directory isn't set as the home directory of the user. This means that if a user inadvertently runs ``cd`` with no arguments from the terminal, they will end up back in the home directory.
 
-To try and avoid confusion and provide a means for a user to easily get back to where they need to be, it is recommended if instructing users to change directories, to always provide a full path relative to the home directory. Thus use a path of the form ``~/exercises/example-1`` rather than ``example-1``, to the ``cd`` command if changing directories. By using a full path, they can execute the command again and know they will end up back in the required location.
+To try and avoid confusion and provide a means for a user to easily get back to where they need to be, it is recommended if instructing users to change directories, to always provide a full path relative to the home directory. Thus use a path of the form ``~/exercises/example-1`` or ``$HOME/exercises/example-1`` rather than ``example-1``, to the ``cd`` command if changing directories. By using a full path, they can execute the command again and know they will end up back in the required location.
 
 (modifying-workshop-content)=
 Modifying workshop content

--- a/project-docs/release-notes/version-2.7.0.md
+++ b/project-docs/release-notes/version-2.7.0.md
@@ -124,6 +124,12 @@ Features Changed
   interface was previously addressed, but the option to disable bracketed paste
   mode in `bash` wasn't removed at the time when it should have.
 
+* When using a editor clickable action, you could use a target path starting
+  with `~/` to denote a file relative to the home directory of the workshop
+  user. You can now also use the prefix `$HOME/`. Both are to avoid hard coding
+  the `/home/eduk8s` path, which could in the future change if the name of the
+  workshop user were ever changed.
+
 Bugs Fixed
 ----------
 

--- a/project-docs/workshop-content/workshop-instructions.md
+++ b/project-docs/workshop-content/workshop-instructions.md
@@ -355,7 +355,7 @@ file: ~/exercises/sample.txt
 ```
 ~~~
 
-You can use ``~/`` prefix to indicate the path relative to the home directory of the session. On opening the file, if you want the insertion point left on a specific line, provide the ``line`` property. Lines numbers start at ``1``.
+You can use ``~/`` or ``$HOME/`` prefix to indicate the path relative to the home directory of the session. On opening the file, if you want the insertion point left on a specific line, provide the ``line`` property. Lines numbers start at ``1``.
 
 ~~~text
 ```editor:open-file

--- a/workshop-images/base-environment/opt/renderer/src/frontend/scripts/educates.ts
+++ b/workshop-images/base-environment/opt/renderer/src/frontend/scripts/educates.ts
@@ -228,6 +228,8 @@ class Editor {
     private fixup_path(file: string) {
         if (file.startsWith("~/"))
             file = file.replace("~/", "/home/eduk8s/")
+        else if (file.startsWith("$HOME/"))
+            file = file.replace("$HOME/", "/home/eduk8s/")
         else if (!file.startsWith("/"))
             file = path.join("/home/eduk8s", file)
         return file


### PR DESCRIPTION
closes https://github.com/vmware-tanzu-labs/educates-training-platform/issues/99