### PR TITLE
Add kopf client timeout and adjust server timeout to 5 minutes.

### DIFF
--- a/secrets-manager/main.py
+++ b/secrets-manager/main.py
@@ -27,7 +27,8 @@ _stop_flag = Event()
 def configure(settings: kopf.OperatorSettings, **_):
     settings.posting.level = logging.DEBUG
     settings.watching.connect_timeout = 1 * 60
-    settings.watching.server_timeout = 10 * 60
+    settings.watching.server_timeout = 5 * 60
+    settings.watching.client_timeout = settings.watching.server_timeout + 10
 
 
 @kopf.on.login()

--- a/session-manager/main.py
+++ b/session-manager/main.py
@@ -32,7 +32,8 @@ _stop_flag = Event()
 def configure(settings: kopf.OperatorSettings, **_):
     settings.posting.level = logging.DEBUG
     settings.watching.connect_timeout = 1 * 60
-    settings.watching.server_timeout = 10 * 60
+    settings.watching.server_timeout = 5 * 60
+    settings.watching.client_timeout = settings.watching.server_timeout + 10
 
 
 @kopf.on.login()

--- a/training-portal/src/project/apps/workshops/manager/operator.py
+++ b/training-portal/src/project/apps/workshops/manager/operator.py
@@ -138,7 +138,8 @@ stop_flag = Event()
 def configure(settings: kopf.OperatorSettings, **_):
     settings.posting.level = logging.DEBUG
     settings.watching.connect_timeout = 1 * 60
-    settings.watching.server_timeout = 10 * 60
+    settings.watching.server_timeout = 5 * 60
+    settings.watching.client_timeout = settings.watching.server_timeout + 10
 
 
 @kopf.on.login()

--- a/tunnel-manager/main.py
+++ b/tunnel-manager/main.py
@@ -42,7 +42,8 @@ def xgetattr(obj, key, default=None):
 def configure(settings: kopf.OperatorSettings, **_):
     settings.posting.level = logging.DEBUG
     settings.watching.connect_timeout = 1 * 60
-    settings.watching.server_timeout = 10 * 60
+    settings.watching.server_timeout = 5 * 60
+    settings.watching.client_timeout = settings.watching.server_timeout + 10
 
 
 @kopf.on.login()


### PR DESCRIPTION
Further changes related to https://github.com/vmware-tanzu-labs/educates-training-platform/issues/202