### PR TITLE
Pin macos version under GitHub actions so uses Intel runner.

### DIFF
--- a/.github/workflows/build-and-publish-images.yaml
+++ b/.github/workflows/build-and-publish-images.yaml
@@ -668,7 +668,7 @@ jobs:
 
   build-client-programs-darwin-amd64:
     name: Build (clients) / amd64@darwin
-    runs-on: macos-latest
+    runs-on: macos-12
 
     steps:
       - name: Check out the repository
@@ -710,7 +710,7 @@ jobs:
 
   build-client-programs-darwin-arm64:
     name: Build (clients) / arm64@darwin
-    runs-on: macos-latest
+    runs-on: macos-12
 
     steps:
       - name: Check out the repository


### PR DESCRIPTION
Under GitHub actions, macos-latest runner has been changed from AMD64 macos-12 to ARM64 macos-14. Pin runner to old AMR64 version for now and revisit how to cross compile to AMD64 from ARM64 later. Need to double check DNS resolver usage when revisit direction of cross compilation.

GitHub actions announcement and runner details:

* https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image/
* https://github.com/actions/runner-images?tab=readme-ov-file#available-images