### PR TITLE
Update CSP directives targeting Google Analytics

### DIFF
--- a/project-docs/release-notes/version-2.7.1.md
+++ b/project-docs/release-notes/version-2.7.1.md
@@ -37,3 +37,8 @@ Bugs Fixed
   from inside of the workshop session by modifying the injected workshop
   definition. This included not being able to change workshop/terminal layout
   and whether the dashboard tabs for the editor and console were displayed.
+
+* The builtin Google Analytics integration was broken due to the `TrainingPortal`
+  Content Security Policy (CSP) directives declaring outdated sources. The CSPs
+  now allow for `*.google-analytics.com` and `*.googletagmanager.com` to be
+  referenced.

--- a/training-portal/src/project/settings.py
+++ b/training-portal/src/project/settings.py
@@ -227,7 +227,7 @@ CORS_ALLOW_ALL_ORIGINS = True
 CSP_CONNECT_SRC = (
     "'self'",
     f"*.{INGRESS_DOMAIN}",
-    "www.google-analytics.com",
+    "*.google-analytics.com",
     "*.clarity.ms",
     "c.bing.com",
     "*.amplitude.com",
@@ -240,8 +240,8 @@ CSP_SCRIPT_SRC = ("'self'", "www.clarity.ms", "cdn.amplitude.com")
 CSP_IMG_SRC = (
     "'self'",
     "data:",
-    "www.google-analytics.com",
-    "www.googletagmanager.com",
+    "*.google-analytics.com",
+    "*.googletagmanager.com",
 )
 CSP_FONT_SRC = ("'self'",)
 CSP_FRAME_SRC = ("'self'",)


### PR DESCRIPTION
Change fixed `www` prefix for `google-analytics.com` and `googletagmanager.com` into wildcard.

This is related to [this Slack thread](https://kubernetes.slack.com/archives/C05UWT4SKRV/p1716365009570249), I opted for changing the `www.googletagmanager.com` directive in addition to the `google-analytics.com` directive that has already proven faulty, as I thought there might occur similar problems down the road for `googletagmanager.com` at some point.

I will build the training-portal image and test it, will report back if this resolves the issue.

Fixes #377