### PR TITLE
Increase timeout for workshop session registration.

### DIFF
--- a/project-docs/release-notes/version-2.7.1.md
+++ b/project-docs/release-notes/version-2.7.1.md
@@ -52,3 +52,12 @@ Bugs Fixed
 * The workshop title in the dropdown TOC of the workshop instructions was not
   being populated with the workshop title from the workshop definition when the
   Hugo renderer was being used.
+
+* If a workshop session had not been registered by the session manager within 30
+  seconds of creation and a workshop allocation was pending, the workshop
+  allocation would not progress properly to the allocated state and any request
+  objects associated with the workshop session would not be created. From the
+  perspective of a workshop user the session would still appear to work as the
+  workshop dashboard would still be accessible, but request objects would be
+  missing. Timeout for workshop session registration has been increased to 90
+  seconds.

--- a/session-manager/handlers/workshopallocation.py
+++ b/session-manager/handlers/workshopallocation.py
@@ -91,7 +91,7 @@ def workshop_allocation_create(
     parameters_name = f"{session_name}-request"
 
     if not (None, environment_name) in workshop_environment_index:
-        if runtime.total_seconds() >= 30:
+        if runtime.total_seconds() >= 45:
             patch["status"] = {
                 OPERATOR_STATUS_KEY: {
                     "phase": "Failed",
@@ -122,7 +122,7 @@ def workshop_allocation_create(
     environment_instance, *_ = workshop_environment_index[(None, environment_name)]
 
     if not (None, session_name) in workshop_session_index:
-        if runtime.total_seconds() >= 30:
+        if runtime.total_seconds() >= 90:
             patch["status"] = {
                 OPERATOR_STATUS_KEY: {
                     "phase": "Failed",


### PR DESCRIPTION
fixes https://github.com/vmware-tanzu-labs/educates-training-platform/issues/343