### PR TITLE
Fix vcluster DNS lookup and update kubectl versions.

### DIFF
--- a/carvel-packages/training-platform/bundle/config/00-values.yaml
+++ b/carvel-packages/training-platform/bundle/config/00-values.yaml
@@ -6,14 +6,14 @@ imageVersions:
   image: "debian:sid-20230502-slim"
 - name: docker-in-docker
   image: "docker:20.10.18-dind"
-- name: rancher-k3s-v1.25
-  image: "rancher/k3s:v1.25.16-k3s4"
-- name: rancher-k3s-v1.26
-  image: "rancher/k3s:v1.26.12-k3s1"
 - name: rancher-k3s-v1.27
-  image: "rancher/k3s:v1.27.9-k3s1"
+  image: "rancher/k3s:v1.27.14-k3s1"
 - name: rancher-k3s-v1.28
-  image: "rancher/k3s:v1.28.5-k3s1"
+  image: "rancher/k3s:v1.28.10-k3s1"
+- name: rancher-k3s-v1.29
+  image: "rancher/k3s:v1.29.5-k3s1"
+- name: rancher-k3s-v1.30
+  image: "rancher/k3s:v1.30.1-k3s1"
 - name: loftsh-vcluster
   image: "loftsh/vcluster:0.18.1"
 - name: contour-bundle

--- a/carvel-packages/training-platform/config/images.yaml
+++ b/carvel-packages/training-platform/config/images.yaml
@@ -45,14 +45,14 @@ imageVersions:
   image: "debian:sid-20230502-slim"
 - name: docker-in-docker
   image: "docker:20.10.18-dind"
-- name: rancher-k3s-v1.25
-  image: "rancher/k3s:v1.25.16-k3s4"
-- name: rancher-k3s-v1.26
-  image: "rancher/k3s:v1.26.12-k3s1"
 - name: rancher-k3s-v1.27
-  image: "rancher/k3s:v1.27.9-k3s1"
+  image: "rancher/k3s:v1.27.14-k3s1"
 - name: rancher-k3s-v1.28
-  image: "rancher/k3s:v1.28.5-k3s1"
+  image: "rancher/k3s:v1.28.10-k3s1"
+- name: rancher-k3s-v1.29
+  image: "rancher/k3s:v1.29.5-k3s1"
+- name: rancher-k3s-v1.30
+  image: "rancher/k3s:v1.30.1-k3s1"
 - name: loftsh-vcluster
   image: "loftsh/vcluster:0.18.1"
 - name: contour-bundle

--- a/project-docs/release-notes/version-2.7.1.md
+++ b/project-docs/release-notes/version-2.7.1.md
@@ -116,3 +116,7 @@ Bugs Fixed
   longer works when xterm.js is embedded in an iframe. The implementation used
   by xterm.js when clicking on links to open the window has been overridden to
   use the older mechanism.
+
+* DNS resolution was not working from pods deployed to a virtual cluster. Issue
+  fixed and `vcluster` updated to 0.18.1, with support for Kubernetes versions
+  1.27-1.30, defaulting to 1.29.

--- a/project-docs/release-notes/version-2.7.1.md
+++ b/project-docs/release-notes/version-2.7.1.md
@@ -18,6 +18,8 @@ Features Changed
 
 * Updated VS Code to version 1.89.1.
 
+* Versions of kubectl now provided are 1.27-1.30.
+
 * Reduction of noise in logging for session manager, secrets manager and
   training portal, with additional more specific logging on what each is doing.
 

--- a/session-manager/handlers/application_vcluster.py
+++ b/session-manager/handlers/application_vcluster.py
@@ -5,22 +5,22 @@ from .helpers import xget
 from .operator_config import (
     OPERATOR_API_GROUP,
     CLUSTER_STORAGE_GROUP,
-    RANCHER_K3S_V1_25_IMAGE,
-    RANCHER_K3S_V1_26_IMAGE,
     RANCHER_K3S_V1_27_IMAGE,
     RANCHER_K3S_V1_28_IMAGE,
+    RANCHER_K3S_V1_29_IMAGE,
+    RANCHER_K3S_V1_30_IMAGE,
     LOFTSH_VCLUSTER_IMAGE,
     CONTOUR_BUNDLE_IMAGE,
 )
 
 
-K8S_DEFAULT_VERSION = "1.27"
+K8S_DEFAULT_VERSION = "1.29"
 
 K3S_VERSIONS = {
-    "1.25": RANCHER_K3S_V1_25_IMAGE,
-    "1.26": RANCHER_K3S_V1_26_IMAGE,
     "1.27": RANCHER_K3S_V1_27_IMAGE,
     "1.28": RANCHER_K3S_V1_28_IMAGE,
+    "1.29": RANCHER_K3S_V1_29_IMAGE,
+    "1.30": RANCHER_K3S_V1_30_IMAGE,
 }
 
 
@@ -186,21 +186,14 @@ spec:
             - name: custom-config-volume
               mountPath: /etc/coredns/custom
               readOnly: true
-          ports:
-            - containerPort: 1053
-              name: dns
-              protocol: UDP
-            - containerPort: 1053
-              name: dns-tcp
-              protocol: TCP
-            - containerPort: 9153
-              name: metrics
-              protocol: TCP
           securityContext:
+            runAsNonRoot: true
             runAsUser: {{.RUN_AS_USER}}
-            runAsNonRoot: {{.RUN_AS_NON_ROOT}}
+            runAsGroup: {{.RUN_AS_GROUP}}
             allowPrivilegeEscalation: false
             capabilities:
+              add:
+                - NET_BIND_SERVICE
               drop:
                 - ALL
             readOnlyRootFilesystem: true

--- a/session-manager/handlers/operator_config.py
+++ b/session-manager/handlers/operator_config.py
@@ -163,10 +163,10 @@ workshop_images_table = {
     "conda-environment:*": CONDA_ENVIRONMENT_IMAGE,
 }
 
-RANCHER_K3S_V1_25_IMAGE = image_reference("rancher-k3s-v1.25")
-RANCHER_K3S_V1_26_IMAGE = image_reference("rancher-k3s-v1.26")
 RANCHER_K3S_V1_27_IMAGE = image_reference("rancher-k3s-v1.27")
 RANCHER_K3S_V1_28_IMAGE = image_reference("rancher-k3s-v1.28")
+RANCHER_K3S_V1_29_IMAGE = image_reference("rancher-k3s-v1.29")
+RANCHER_K3S_V1_30_IMAGE = image_reference("rancher-k3s-v1.30")
 
 LOFTSH_VCLUSTER_IMAGE = image_reference("loftsh-vcluster")
 

--- a/workshop-images/base-environment/Dockerfile
+++ b/workshop-images/base-environment/Dockerfile
@@ -148,42 +148,9 @@ RUN mkdir -p /opt/kubernetes/bin
 
 RUN <<EOF
     set -eo pipefail
-    VERSION=1.24.17
-    CHECKSUM_amd64="3e9588e3326c7110a163103fc3ea101bb0e85f4d6fd228cf928fa9a2a20594d5"
-    CHECKSUM_arm64="66885bda3a202546778c77f0b66dcf7f576b5a49ff9456acf61329da784a602d"
-    CHECKSUM=CHECKSUM_${TARGETARCH}
-    curl --silent --fail -L -o /opt/kubernetes/bin/kubectl@1.24 https://storage.googleapis.com/kubernetes-release/release/v${VERSION}/bin/linux/${TARGETARCH}/kubectl
-    echo "${!CHECKSUM} /opt/kubernetes/bin/kubectl@1.24" | sha256sum --check --status
-    chmod +x /opt/kubernetes/bin/kubectl@1.24
-EOF
-
-RUN <<EOF
-    set -eo pipefail
-    VERSION=1.25.16
-    CHECKSUM_amd64="5a9bc1d3ebfc7f6f812042d5f97b82730f2bdda47634b67bddf36ed23819ab17"
-    CHECKSUM_arm64="d6c23c80828092f028476743638a091f2f5e8141273d5228bf06c6671ef46924"
-    CHECKSUM=CHECKSUM_${TARGETARCH}
-    curl --silent --fail -L -o /opt/kubernetes/bin/kubectl@1.25 https://storage.googleapis.com/kubernetes-release/release/v${VERSION}/bin/linux/${TARGETARCH}/kubectl
-    echo "${!CHECKSUM} /opt/kubernetes/bin/kubectl@1.25" | sha256sum --check --status
-    chmod +x /opt/kubernetes/bin/kubectl@1.25
-EOF
-
-RUN <<EOF
-    set -eo pipefail
-    VERSION=1.26.11
-    CHECKSUM_amd64="27c34a0870230d9dd723e1e01114634e396cd2a3d25ced263b769a4bd53e4edd"
-    CHECKSUM_arm64="4a6d2b7204af3cf84cd0e2c670fbb211501050c9a288de49de3c6363d4e0a63e"
-    CHECKSUM=CHECKSUM_${TARGETARCH}
-    curl --silent --fail -L -o /opt/kubernetes/bin/kubectl@1.26 https://storage.googleapis.com/kubernetes-release/release/v${VERSION}/bin/linux/${TARGETARCH}/kubectl
-    echo "${!CHECKSUM} /opt/kubernetes/bin/kubectl@1.26" | sha256sum --check --status
-    chmod +x /opt/kubernetes/bin/kubectl@1.26
-EOF
-
-RUN <<EOF
-    set -eo pipefail
-    VERSION=1.27.8
-    CHECKSUM_amd64="027b3161e99fa0a7fa529e8f17f73ee2c0807c81c721ca7cf307f6b41c17bc57"
-    CHECKSUM_arm64="97ed6739e2803e63fd2d9de78be22d5ba6205bb63179a16ec773063526525a8e"
+    VERSION=1.27.14
+    CHECKSUM_amd64="1d2431c68bb6dfa9de3cd40fd66d97a9ac73593c489f9467249eea43e9c16a1e"
+    CHECKSUM_arm64="29f3a1f520d929df38873c68dec73519c1e5e521140e01cf9d7701f7b5ffe4f3"
     CHECKSUM=CHECKSUM_${TARGETARCH}
     curl --silent --fail -L -o /opt/kubernetes/bin/kubectl@1.27 https://storage.googleapis.com/kubernetes-release/release/v${VERSION}/bin/linux/${TARGETARCH}/kubectl
     echo "${!CHECKSUM} /opt/kubernetes/bin/kubectl@1.27" | sha256sum --check --status
@@ -192,13 +159,35 @@ EOF
 
 RUN <<EOF
     set -eo pipefail
-    VERSION=1.28.4
-    CHECKSUM_amd64="893c92053adea6edbbd4e959c871f5c21edce416988f968bec565d115383f7b8"
-    CHECKSUM_arm64="edf1e17b41891ec15d59dd3cc62bcd2cdce4b0fd9c2ee058b0967b17534457d7"
+    VERSION=1.28.10
+    CHECKSUM_amd64="389c17a9700a4b01ebb055e39b8bc0886330497440dde004b5ed90f2a3a028db"
+    CHECKSUM_arm64="e659d23d442c2706debe5b96742326c0a1e1d7b5c695a9fe7dfe8ea7402caee8"
     CHECKSUM=CHECKSUM_${TARGETARCH}
     curl --silent --fail -L -o /opt/kubernetes/bin/kubectl@1.28 https://storage.googleapis.com/kubernetes-release/release/v${VERSION}/bin/linux/${TARGETARCH}/kubectl
     echo "${!CHECKSUM} /opt/kubernetes/bin/kubectl@1.28" | sha256sum --check --status
     chmod +x /opt/kubernetes/bin/kubectl@1.28
+EOF
+
+RUN <<EOF
+    set -eo pipefail
+    VERSION=1.29.5
+    CHECKSUM_amd64="603c8681fc0d8609c851f9cc58bcf55eeb97e2934896e858d0232aa8d1138366"
+    CHECKSUM_arm64="9ee9168def12ac6a6c0c6430e0f73175e756ed262db6040f8aa2121ad2c1f62e"
+    CHECKSUM=CHECKSUM_${TARGETARCH}
+    curl --silent --fail -L -o /opt/kubernetes/bin/kubectl@1.29 https://storage.googleapis.com/kubernetes-release/release/v${VERSION}/bin/linux/${TARGETARCH}/kubectl
+    echo "${!CHECKSUM} /opt/kubernetes/bin/kubectl@1.29" | sha256sum --check --status
+    chmod +x /opt/kubernetes/bin/kubectl@1.29
+EOF
+
+RUN <<EOF
+    set -eo pipefail
+    VERSION=1.30.1
+    CHECKSUM_amd64="5b86f0b06e1a5ba6f8f00e2b01e8ed39407729c4990aeda961f83a586f975e8a"
+    CHECKSUM_arm64="d90446719b815e3abfe7b2c46ddf8b3fda17599f03ab370d6e47b1580c0e869e"
+    CHECKSUM=CHECKSUM_${TARGETARCH}
+    curl --silent --fail -L -o /opt/kubernetes/bin/kubectl@1.30 https://storage.googleapis.com/kubernetes-release/release/v${VERSION}/bin/linux/${TARGETARCH}/kubectl
+    echo "${!CHECKSUM} /opt/kubernetes/bin/kubectl@1.30" | sha256sum --check --status
+    chmod +x /opt/kubernetes/bin/kubectl@1.30
 EOF
 
 RUN <<EOF

--- a/workshop-images/base-environment/opt/eduk8s/etc/setup.d/01-kubernetes.sh
+++ b/workshop-images/base-environment/opt/eduk8s/etc/setup.d/01-kubernetes.sh
@@ -42,19 +42,19 @@ fi
 KUBECTL_VERSION=$(kubectl version -o json | jq -re '[.serverVersion.major,.serverVersion.minor]|join(".")' | sed -e 's/^\([1-9]*.[1-9]*\).*$/\1/')
 
 case "$KUBECTL_VERSION" in
-1.2[0123])
-    KUBECTL_VERSION=1.24
+1.2[0123456])
+    KUBECTL_VERSION=1.27
     ;;
-1.2[9])
-    KUBECTL_VERSION=1.28
+1.30)
+    KUBECTL_VERSION=1.30
     ;;
 1.3*)
-    KUBECTL_VERSION=1.28
+    KUBECTL_VERSION=1.30
     ;;
 esac
 
 if [ -z "$KUBECTL_VERSION" ]; then
-    KUBECTL_VERSION=1.28
+    KUBECTL_VERSION=1.29
 fi
 
 # Restrict access permissions on kubeconfig file as some clients will complain

--- a/workshop-images/base-environment/opt/kubernetes/bin/kubectl
+++ b/workshop-images/base-environment/opt/kubernetes/bin/kubectl
@@ -1,23 +1,23 @@
 #!/bin/bash
 
 case "$KUBECTL_VERSION" in
-1.2[0123])
-    KUBECTL_VERSION=1.24
+1.2[0123456])
+    KUBECTL_VERSION=1.27
     ;;
-1.2[9])
-    KUBECTL_VERSION=1.28
+1.30)
+    KUBECTL_VERSION=1.30
     ;;
 1.3*)
-    KUBECTL_VERSION=1.28
+    KUBECTL_VERSION=1.30
     ;;
 esac
 
 if [ -z "$KUBECTL_VERSION" ]; then
-    KUBECTL_VERSION=1.28
+    KUBECTL_VERSION=1.29
 fi
 
 if [ ! -x /opt/kubernetes/bin/kubectl@$KUBECTL_VERSION ]; then
-    KUBECTL_VERSION=1.28
+    KUBECTL_VERSION=1.29
 fi
 
 exec /opt/kubernetes/bin/kubectl@$KUBECTL_VERSION "$@"


### PR DESCRIPTION
Updated vcluster to 0.18.1. Note that not gone to 0.19.x as that version changes the architecture of how vcluster is deployed. Updated kubectl versions and vcluster to support 1.27-1.30, defaulting to 1.29.