### PR TITLE
Fixing duplicate log messages, cmd output and makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,15 +151,16 @@ push-installer-bundle:
 
 deploy-installer:
 ifneq ("$(wildcard developer-testing/educates-installer-values.yaml)","")
-	kubectl create ns educates-installer || true
+	-kubectl create ns educates-installer
 	ytt --file carvel-packages/installer/bundle/config --data-values-file developer-testing/educates-installer-values.yaml | kapp deploy -a label:installer=educates-installer.app -n educates-installer -f - -y
 else
-	kubectl create ns educates-installer || true
+	-kubectl create ns educates-installer
 	ytt --file carvel-packages/installer/bundle/config | kapp deploy -a label:installer=educates-installer.app -n educates-installer -f - -y
 endif
 
 delete-installer:
 	kapp delete -a educates-installer -y
+	-kubectl delete ns educates-installer
 
 deploy-installer-bundle: push-installer-bundle
 	kubectl get ns/educates-package || kubectl create ns educates-package

--- a/client-programs/pkg/cmd/admin_cluster_create_cmd.go
+++ b/client-programs/pkg/cmd/admin_cluster_create_cmd.go
@@ -29,17 +29,23 @@ var (
 	educates admin cluster create
 
 	# Create local educates cluster with custom configuration
-  educates admin cluster create --config config.yaml
+	educates admin cluster create --config config.yaml
 
-  # Create local educates cluster and sync local educates secrets
-  educates admin cluster install --config config.yaml --with-local-secrets
+	# Create local kind cluster but don't install anything on it (it creates local registry but not local secrets)
+	educates admin cluster create --cluster-only
 
-  # Create local educates cluster with bundle from different repository
-  educates admin cluster create --package-repository ghcr.io/jorgemoralespou --version installer-clean
+	# Create local kind cluster but don't install anything on it, but providing some config for kind
+	educates admin cluster create --cluster-only --config config.yaml
 
-  # Create local educates cluster with local build (for development)
-  educates admin cluster create --package-repository localhost:5001 --version 0.0.1
-  `
+	# Create local educates cluster and sync local educates secrets
+	educates admin cluster create --config config.yaml --with-local-secrets
+
+	# Create local educates cluster with bundle from different repository
+	educates admin cluster create --package-repository ghcr.io/jorgemoralespou --version installer-clean
+
+	# Create local educates cluster with local build (for development)
+	educates admin cluster create --package-repository localhost:5001 --version 0.0.1
+`
 )
 
 type AdminClusterCreateOptions struct {

--- a/client-programs/pkg/registry/registry.go
+++ b/client-programs/pkg/registry/registry.go
@@ -114,7 +114,7 @@ func DeployRegistry() error {
 func AddRegistryConfigToKindNodes(repositoryName string) error {
 	ctx := context.Background()
 
-	fmt.Println("Adding local image registry config to Kind nodes")
+	fmt.Printf("Adding local image registry config (%s) to Kind nodes\n", repositoryName)
 
 	cli, err := client.NewClientWithOpts(client.FromEnv)
 


### PR DESCRIPTION
This changes adds more qualification to duplicate messages when linking cluster to local registry. Fixes format of cluster-create command and adds `ns delete` to makefile target

Closes #409 
Closes #410 
Closes #411 