### PR TITLE
Saving clusterPackages config into the cluster

### DIFF
--- a/carvel-packages/installer/bundle/config/ytt/_ytt_lib/config/save-config-overlay.yaml
+++ b/carvel-packages/installer/bundle/config/ytt/_ytt_lib/config/save-config-overlay.yaml
@@ -1,0 +1,16 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: educates-config
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: educates-config
+  namespace: educates-config
+data:
+  values.yaml: #@ data.values

--- a/carvel-packages/installer/bundle/config/ytt/config.yaml
+++ b/carvel-packages/installer/bundle/config/ytt/config.yaml
@@ -38,4 +38,5 @@
 --- #@ template.replace(overlay.apply(library.get(packagePath).with_data_values(packageValues).eval(), addKappAnnotations(name, overlayedValues, orderedPackagesList)))
 #@     end
 #@   end
+--- #@ template.replace(overlay.apply(library.get("config").with_data_values(overlayedValues).eval()))
 #@ end


### PR DESCRIPTION
ClusterPackages config is saved into the cluster in `educates-config` configmap in `educates-config` namespace.

ClusterInfrastructure configuration is not saved, it's only the rendered configuration for the packages. 

Closes #417 