### PR TITLE
Updates to platform deployment using CLI.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ push-installer-bundle:
 	ytt -f carvel-packages/installer/bundle --data-values-schema-inspect -o openapi-v3 > developer-testing/educates-training-platform-schema-openapi.yaml
 	ytt -f carvel-packages/installer/config/package.yaml -f carvel-packages/installer/config/schema.yaml -v imageRegistry.host=$(IMAGE_REPOSITORY) -v version=$(RELEASE_VERSION) -v releasedAt=`date -u +"%Y-%m-%dT%H:%M:%SZ"` --data-value-file openapi=developer-testing/educates-training-platform-schema-openapi.yaml > developer-testing/educates-installer.yaml
 
-deploy-installer:
+deploy-platform:
 ifneq ("$(wildcard developer-testing/educates-installer-values.yaml)","")
 	-kubectl create ns educates-installer
 	ytt --file carvel-packages/installer/bundle/config --data-values-file developer-testing/educates-installer-values.yaml | kapp deploy -a label:installer=educates-installer.app -n educates-installer -f - -y
@@ -158,11 +158,11 @@ else
 	ytt --file carvel-packages/installer/bundle/config | kapp deploy -a label:installer=educates-installer.app -n educates-installer -f - -y
 endif
 
-delete-installer:
+delete-platform:
 	kapp delete -a educates-installer -y
 	-kubectl delete ns educates-installer
 
-deploy-installer-bundle: push-installer-bundle
+deploy-platform-bundle: push-installer-bundle
 	kubectl get ns/educates-package || kubectl create ns educates-package
 	kubectl apply --namespace educates-package -f carvel-packages/installer/config/metadata.yaml
 	kubectl apply --namespace educates-package -f developer-testing/educates-installer.yaml
@@ -172,7 +172,7 @@ else
 	kctrl package install --namespace educates-package --package-install educates-installer --package installer.educates.dev --version $(RELEASE_VERSION)
 endif
 
-delete-installer-bundle:
+delete-platform-bundle:
 	kctrl package installed delete --namespace educates-package --package-install educates-installer -y
 
 restart-training-platform:

--- a/carvel-packages/installer/bundle/config/ytt/_ytt_lib/infrastructure/custom/educates.lib.yaml
+++ b/carvel-packages/installer/bundle/config/ytt/_ytt_lib/infrastructure/custom/educates.lib.yaml
@@ -72,7 +72,7 @@ trainingPortal:
       username: #@ data.values.trainingPortal.credentials.admin.username
       #@ if/end hasattr(data.values.trainingPortal.credentials.admin, "password") and data.values.trainingPortal.credentials.admin.password != None:
       password: #@ data.values.trainingPortal.credentials.admin.password
-    #@ if/end hasattr(data.values.trainingPortal.credentials, "admin") and data.values.trainingPortal.credentials.admin != None:
+    #@ if/end hasattr(data.values.trainingPortal.credentials, "robot") and data.values.trainingPortal.credentials.robot != None:
     robot:
       #@ if/end hasattr(data.values.trainingPortal.credentials.robot, "username") and data.values.trainingPortal.credentials.robot.username != None:
       username: #@ data.values.trainingPortal.credentials.robot.username
@@ -80,7 +80,7 @@ trainingPortal:
       password: #@ data.values.trainingPortal.credentials.robot.password
   #@ if/end hasattr(data.values.trainingPortal, "clients") and data.values.trainingPortal.clients != None:
   clients:
-    #@ if/end hasattr(data.values.trainingPortal.clients, "admin") and data.values.trainingPortal.clients.admin != None:
+    #@ if/end hasattr(data.values.trainingPortal.clients, "robot") and data.values.trainingPortal.clients.robot != None:
     robot:
       #@ if/end hasattr(data.values.trainingPortal.clients.robot, "id") and data.values.trainingPortal.clients.robot.id != None:
       id: #@ data.values.trainingPortal.clients.robot.id

--- a/carvel-packages/installer/bundle/config/ytt/_ytt_lib/infrastructure/eks/educates.lib.yaml
+++ b/carvel-packages/installer/bundle/config/ytt/_ytt_lib/infrastructure/eks/educates.lib.yaml
@@ -72,7 +72,7 @@ trainingPortal:
       username: #@ data.values.trainingPortal.credentials.admin.username
       #@ if/end hasattr(data.values.trainingPortal.credentials.admin, "password") and data.values.trainingPortal.credentials.admin.password != None:
       password: #@ data.values.trainingPortal.credentials.admin.password
-    #@ if/end hasattr(data.values.trainingPortal.credentials, "admin") and data.values.trainingPortal.credentials.admin != None:
+    #@ if/end hasattr(data.values.trainingPortal.credentials, "robot") and data.values.trainingPortal.credentials.robot != None:
     robot:
       #@ if/end hasattr(data.values.trainingPortal.credentials.robot, "username") and data.values.trainingPortal.credentials.robot.username != None:
       username: #@ data.values.trainingPortal.credentials.robot.username
@@ -80,7 +80,7 @@ trainingPortal:
       password: #@ data.values.trainingPortal.credentials.robot.password
   #@ if/end hasattr(data.values.trainingPortal, "clients") and data.values.trainingPortal.clients != None:
   clients:
-    #@ if/end hasattr(data.values.trainingPortal.clients, "admin") and data.values.trainingPortal.clients.admin != None:
+    #@ if/end hasattr(data.values.trainingPortal.clients, "robot") and data.values.trainingPortal.clients.robot != None:
     robot:
       #@ if/end hasattr(data.values.trainingPortal.clients.robot, "id") and data.values.trainingPortal.clients.robot.id != None:
       id: #@ data.values.trainingPortal.clients.robot.id

--- a/carvel-packages/installer/bundle/config/ytt/_ytt_lib/infrastructure/gke/educates.lib.yaml
+++ b/carvel-packages/installer/bundle/config/ytt/_ytt_lib/infrastructure/gke/educates.lib.yaml
@@ -72,7 +72,7 @@ trainingPortal:
       username: #@ data.values.trainingPortal.credentials.admin.username
       #@ if/end hasattr(data.values.trainingPortal.credentials.admin, "password") and data.values.trainingPortal.credentials.admin.password != None:
       password: #@ data.values.trainingPortal.credentials.admin.password
-    #@ if/end hasattr(data.values.trainingPortal.credentials, "admin") and data.values.trainingPortal.credentials.admin != None:
+    #@ if/end hasattr(data.values.trainingPortal.credentials, "robot") and data.values.trainingPortal.credentials.robot != None:
     robot:
       #@ if/end hasattr(data.values.trainingPortal.credentials.robot, "username") and data.values.trainingPortal.credentials.robot.username != None:
       username: #@ data.values.trainingPortal.credentials.robot.username
@@ -80,7 +80,7 @@ trainingPortal:
       password: #@ data.values.trainingPortal.credentials.robot.password
   #@ if/end hasattr(data.values.trainingPortal, "clients") and data.values.trainingPortal.clients != None:
   clients:
-    #@ if/end hasattr(data.values.trainingPortal.clients, "admin") and data.values.trainingPortal.clients.admin != None:
+    #@ if/end hasattr(data.values.trainingPortal.clients, "robot") and data.values.trainingPortal.clients.robot != None:
     robot:
       #@ if/end hasattr(data.values.trainingPortal.clients.robot, "id") and data.values.trainingPortal.clients.robot.id != None:
       id: #@ data.values.trainingPortal.clients.robot.id

--- a/carvel-packages/installer/bundle/config/ytt/_ytt_lib/infrastructure/kind/educates.lib.yaml
+++ b/carvel-packages/installer/bundle/config/ytt/_ytt_lib/infrastructure/kind/educates.lib.yaml
@@ -70,7 +70,7 @@ trainingPortal:
       username: #@ data.values.trainingPortal.credentials.admin.username
       #@ if/end hasattr(data.values.trainingPortal.credentials.admin, "password") and data.values.trainingPortal.credentials.admin.password != None:
       password: #@ data.values.trainingPortal.credentials.admin.password
-    #@ if/end hasattr(data.values.trainingPortal.credentials, "admin") and data.values.trainingPortal.credentials.admin != None:
+    #@ if/end hasattr(data.values.trainingPortal.credentials, "robot") and data.values.trainingPortal.credentials.robot != None:
     robot:
       #@ if/end hasattr(data.values.trainingPortal.credentials.robot, "username") and data.values.trainingPortal.credentials.robot.username != None:
       username: #@ data.values.trainingPortal.credentials.robot.username
@@ -78,7 +78,7 @@ trainingPortal:
       password: #@ data.values.trainingPortal.credentials.robot.password
   #@ if/end hasattr(data.values.trainingPortal, "clients") and data.values.trainingPortal.clients != None:
   clients:
-    #@ if/end hasattr(data.values.trainingPortal.clients, "admin") and data.values.trainingPortal.clients.admin != None:
+    #@ if/end hasattr(data.values.trainingPortal.clients, "robot") and data.values.trainingPortal.clients.robot != None:
     robot:
       #@ if/end hasattr(data.values.trainingPortal.clients.robot, "id") and data.values.trainingPortal.clients.robot.id != None:
       id: #@ data.values.trainingPortal.clients.robot.id

--- a/carvel-packages/installer/bundle/config/ytt/_ytt_lib/infrastructure/vcluster/educates.lib.yaml
+++ b/carvel-packages/installer/bundle/config/ytt/_ytt_lib/infrastructure/vcluster/educates.lib.yaml
@@ -71,7 +71,7 @@ trainingPortal:
       username: #@ data.values.trainingPortal.credentials.admin.username
       #@ if/end hasattr(data.values.trainingPortal.credentials.admin, "password") and data.values.trainingPortal.credentials.admin.password != None:
       password: #@ data.values.trainingPortal.credentials.admin.password
-    #@ if/end hasattr(data.values.trainingPortal.credentials, "admin") and data.values.trainingPortal.credentials.admin != None:
+    #@ if/end hasattr(data.values.trainingPortal.credentials, "robot") and data.values.trainingPortal.credentials.admin != None:
     robot:
       #@ if/end hasattr(data.values.trainingPortal.credentials.robot, "username") and data.values.trainingPortal.credentials.robot.username != None:
       username: #@ data.values.trainingPortal.credentials.robot.username
@@ -79,7 +79,7 @@ trainingPortal:
       password: #@ data.values.trainingPortal.credentials.robot.password
   #@ if/end hasattr(data.values.trainingPortal, "clients") and data.values.trainingPortal.clients != None:
   clients:
-    #@ if/end hasattr(data.values.trainingPortal.clients, "admin") and data.values.trainingPortal.clients.admin != None:
+    #@ if/end hasattr(data.values.trainingPortal.clients, "robot") and data.values.trainingPortal.clients.robot != None:
     robot:
       #@ if/end hasattr(data.values.trainingPortal.clients.robot, "id") and data.values.trainingPortal.clients.robot.id != None:
       id: #@ data.values.trainingPortal.clients.robot.id

--- a/client-programs/pkg/cmd/admin_cluster_cmd_group.go
+++ b/client-programs/pkg/cmd/admin_cluster_cmd_group.go
@@ -24,7 +24,6 @@ func (p *ProjectInfo) NewAdminClusterCmdGroup() *cobra.Command {
 				p.NewAdminClusterStopCmd(),
 				p.NewAdminClusterDeleteCmd(),
 				p.NewAdminClusterStatusCmd(),
-				p.NewAdminClusterInstallCmd(),
 			},
 		},
 	}

--- a/client-programs/pkg/cmd/admin_cluster_create_cmd.go
+++ b/client-programs/pkg/cmd/admin_cluster_create_cmd.go
@@ -66,7 +66,7 @@ func (o *AdminClusterCreateOptions) Run() error {
 	var err error = nil
 
 	if o.Config == "" {
-		fullConfig, err = config.NewDefaultInstallationConfig()
+		fullConfig, err = config.NewInstallationConfigFromUserFile()
 	} else {
 		fullConfig, err = config.NewInstallationConfigFromFile(o.Config)
 	}

--- a/client-programs/pkg/cmd/admin_config_view_cmd.go
+++ b/client-programs/pkg/cmd/admin_config_view_cmd.go
@@ -23,7 +23,7 @@ func (o *AdminConfigViewOptions) Run() error {
 	if o.Config != "" {
 		fullConfig, err = config.NewInstallationConfigFromFile(o.Config)
 	} else {
-		fullConfig, err = config.NewDefaultInstallationConfig()
+		fullConfig, err = config.NewInstallationConfigFromUserFile()
 	}
 
 	if err != nil {

--- a/client-programs/pkg/cmd/admin_platform_cmd_group.go
+++ b/client-programs/pkg/cmd/admin_platform_cmd_group.go
@@ -19,7 +19,8 @@ func (p *ProjectInfo) NewAdminPlatformCmdGroup() *cobra.Command {
 		{
 			Message: "Available Commands:",
 			Commands: []*cobra.Command{
-				p.NewAdminPlatformInstallCmd(),
+				p.NewAdminPlatformDeployCmd(),
+				p.NewAdminPlatformDeleteCmd(),
 			},
 		},
 	}

--- a/client-programs/pkg/cmd/admin_platform_cmd_group.go
+++ b/client-programs/pkg/cmd/admin_platform_cmd_group.go
@@ -5,10 +5,10 @@ import (
 	"k8s.io/kubectl/pkg/util/templates"
 )
 
-func (p *ProjectInfo) NewAdminCmdGroup() *cobra.Command {
+func (p *ProjectInfo) NewAdminPlatformCmdGroup() *cobra.Command {
 	var c = &cobra.Command{
-		Use:   "admin",
-		Short: "Tools for installing Educates on Kubernetes",
+		Use:   "platform",
+		Short: "Manage Educates installation",
 	}
 
 	// Use a command group as it allows us to dictate the order in which they
@@ -19,13 +19,7 @@ func (p *ProjectInfo) NewAdminCmdGroup() *cobra.Command {
 		{
 			Message: "Available Commands:",
 			Commands: []*cobra.Command{
-				p.NewAdminClusterCmdGroup(),
-				p.NewAdminPlatformCmdGroup(),
-				p.NewAdminConfigCmdGroup(),
-				p.NewAdminSecretsCmdGroup(),
-				p.NewAdminRegistryCmdGroup(),
-				p.NewAdminResolverCmdGroup(),
-				p.NewAdminDiagnosticsCmdGroup(),
+				p.NewAdminPlatformInstallCmd(),
 			},
 		},
 	}

--- a/client-programs/pkg/cmd/admin_platform_delete_cmd.go
+++ b/client-programs/pkg/cmd/admin_platform_delete_cmd.go
@@ -11,20 +11,17 @@ import (
 	"github.com/vmware-tanzu-labs/educates-training-platform/client-programs/pkg/installer"
 )
 
-func (o *PlatformDeployOptions) RunDelete() error {
-	fullConfig, err := config.NewInstallationConfigFromFile(o.Config)
+type PlatformDeleteOptions struct {
+	KubeconfigOptions
+	Verbose bool
+}
+
+func (o *PlatformDeleteOptions) Run() error {
+	emptyFile := "/dev/null"
+
+	fullConfig, err := config.NewInstallationConfigFromFile(emptyFile)
 
 	if err != nil {
-		return err
-	}
-
-	// This can be set in the config file if not provided via the command line
-	if o.Provider != "" {
-		fullConfig.ClusterInfrastructure.Provider = o.Provider
-	}
-
-	// Although ytt does some schema validation, we do some basic validation here
-	if err := validateProvider(fullConfig.ClusterInfrastructure.Provider); err != nil {
 		return err
 	}
 
@@ -44,23 +41,17 @@ func (o *PlatformDeployOptions) RunDelete() error {
 }
 
 func (p *ProjectInfo) NewAdminPlatformDeleteCmd() *cobra.Command {
-	var o PlatformDeployOptions
+	var o PlatformDeleteOptions
 
 	var c = &cobra.Command{
 		Args:  cobra.NoArgs,
 		Use:   "delete",
 		Short: "Delete Educates and related cluster services from your cluster",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return o.RunDelete()
+			return o.Run()
 		},
 	}
 
-	c.Flags().StringVar(
-		&o.Config,
-		"config",
-		"",
-		"path to the installation config file for Educates",
-	)
 	c.Flags().StringVar(
 		&o.Kubeconfig,
 		"kubeconfig",
@@ -73,26 +64,12 @@ func (p *ProjectInfo) NewAdminPlatformDeleteCmd() *cobra.Command {
 		"",
 		"Context to use from Kubeconfig",
 	)
-	c.Flags().StringVar(
-		&o.Provider,
-		"provider",
-		"",
-		"infastructure provider deployment is being made to (eks, gke, kind, custom, vcluster)",
+	c.Flags().BoolVar(
+		&o.Verbose,
+		"verbose",
+		false,
+		"print verbose output",
 	)
-	c.Flags().StringVar(
-		&o.PackageRepository,
-		"package-repository",
-		p.ImageRepository,
-		"image repository hosting package bundles",
-	)
-	c.Flags().StringVar(
-		&o.Version,
-		"version",
-		p.Version,
-		"version to be installed",
-	)
-
-	c.MarkFlagRequired("config")
 
 	return c
 }

--- a/client-programs/pkg/cmd/admin_platform_delete_cmd.go
+++ b/client-programs/pkg/cmd/admin_platform_delete_cmd.go
@@ -17,19 +17,13 @@ type PlatformDeleteOptions struct {
 }
 
 func (o *PlatformDeleteOptions) Run() error {
-	emptyFile := "/dev/null"
-
-	fullConfig, err := config.NewInstallationConfigFromFile(emptyFile)
-
-	if err != nil {
-		return err
-	}
+	fullConfig := config.NewDefaultInstallationConfig()
 
 	installer := installer.NewInstaller()
 
 	clusterConfig := cluster.NewClusterConfig(o.Kubeconfig, o.Context)
 
-	err = installer.Delete(fullConfig, clusterConfig, o.Verbose)
+	err := installer.Delete(fullConfig, clusterConfig, o.Verbose)
 
 	if err != nil {
 		return errors.Wrap(err, "educates could not be deleted")

--- a/client-programs/pkg/cmd/admin_platform_delete_cmd.go
+++ b/client-programs/pkg/cmd/admin_platform_delete_cmd.go
@@ -1,0 +1,98 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/vmware-tanzu-labs/educates-training-platform/client-programs/pkg/cluster"
+	"github.com/vmware-tanzu-labs/educates-training-platform/client-programs/pkg/config"
+	"github.com/vmware-tanzu-labs/educates-training-platform/client-programs/pkg/installer"
+)
+
+func (o *PlatformDeployOptions) RunDelete() error {
+	fullConfig, err := config.NewInstallationConfigFromFile(o.Config)
+
+	if err != nil {
+		return err
+	}
+
+	// This can be set in the config file if not provided via the command line
+	if o.Provider != "" {
+		fullConfig.ClusterInfrastructure.Provider = o.Provider
+	}
+
+	// Although ytt does some schema validation, we do some basic validation here
+	if err := validateProvider(fullConfig.ClusterInfrastructure.Provider); err != nil {
+		return err
+	}
+
+	installer := installer.NewInstaller()
+
+	clusterConfig := cluster.NewClusterConfig(o.Kubeconfig, o.Context)
+
+	err = installer.Delete(fullConfig, clusterConfig, o.Verbose)
+
+	if err != nil {
+		return errors.Wrap(err, "educates could not be deleted")
+	}
+
+	fmt.Println("\nEducates has been deleted succesfully")
+
+	return nil
+}
+
+func (p *ProjectInfo) NewAdminPlatformDeleteCmd() *cobra.Command {
+	var o PlatformDeployOptions
+
+	var c = &cobra.Command{
+		Args:  cobra.NoArgs,
+		Use:   "delete",
+		Short: "Delete Educates and related cluster services from your cluster",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return o.RunDelete()
+		},
+	}
+
+	c.Flags().StringVar(
+		&o.Config,
+		"config",
+		"",
+		"path to the installation config file for Educates",
+	)
+	c.Flags().StringVar(
+		&o.Kubeconfig,
+		"kubeconfig",
+		"",
+		"kubeconfig file to use instead of $KUBECONFIG or $HOME/.kube/config",
+	)
+	c.Flags().StringVar(
+		&o.Context,
+		"context",
+		"",
+		"Context to use from Kubeconfig",
+	)
+	c.Flags().StringVar(
+		&o.Provider,
+		"provider",
+		"",
+		"infastructure provider deployment is being made to (eks, gke, kind, custom, vcluster)",
+	)
+	c.Flags().StringVar(
+		&o.PackageRepository,
+		"package-repository",
+		p.ImageRepository,
+		"image repository hosting package bundles",
+	)
+	c.Flags().StringVar(
+		&o.Version,
+		"version",
+		p.Version,
+		"version to be installed",
+	)
+
+	c.MarkFlagRequired("config")
+
+	return c
+}

--- a/client-programs/pkg/cmd/admin_platform_deploy_cmd.go
+++ b/client-programs/pkg/cmd/admin_platform_deploy_cmd.go
@@ -16,39 +16,39 @@ import (
 var (
 	installExample = `
   # Install educates
-  educates admin platform install --config config.yaml
+  educates admin platform deploy --config config.yaml
 
   # Get default configuration for a specific provider
-  educates admin platform install --provider kind --show-packages-values
+  educates admin platform deploy --provider kind --show-packages-values
 
   # Get default configuration for a specific provider with provided config file
-  educates admin platform install --config config.yaml --show-packages-values
+  educates admin platform deploy --config config.yaml --show-packages-values
 
   # Get deployment descriptors for a specific provider with default config
-  educates admin platform install --provider kind --dry-run
+  educates admin platform deploy --provider kind --dry-run
 
   # Get deployment descriptors for a specific provider with provided config
-  educates admin platform install --config config.yaml --dry-run
+  educates admin platform deploy --config config.yaml --dry-run
 
   # Install educates with verbose output
-  educates admin platform install --config config.yaml --verbose
+  educates admin platform deploy --config config.yaml --verbose
 
   # Install educates without resolving images via kbld (using latest images)
-  educates admin platform install --config config.yaml --skip-image-resolution
+  educates admin platform deploy --config config.yaml --skip-image-resolution
 
   # Install educates showing the differences to be applied to the cluster
-  educates admin platform install --config config.yaml --show-diff
+  educates admin platform deploy --config config.yaml --show-diff
 
   # Install educates with bundle from different repository
-  educates admin platform install --config config.yaml --package-repository ghcr.io/jorgemoralespou --version installer-clean
+  educates admin platform deploy --config config.yaml --package-repository ghcr.io/jorgemoralespou --version installer-clean
 
   # Install educates when locally built
-  educates admin platform install --config config.yaml  --package-repository localhost:5001 --version 0.0.1
+  educates admin platform deploy --config config.yaml  --package-repository localhost:5001 --version 0.0.1
 
   # Install educates on a specific cluster
-  educates admin platform install --config config.yaml --kubeconfig /path/to/kubeconfig --context my-cluster
-  educates admin platform install --config config.yaml --kubeconfig /path/to/kubeconfig
-  educates admin platform install --config config.yaml --context my-cluster
+  educates admin platform deploy --config config.yaml --kubeconfig /path/to/kubeconfig --context my-cluster
+  educates admin platform deploy --config config.yaml --kubeconfig /path/to/kubeconfig
+  educates admin platform deploy --config config.yaml --context my-cluster
   `
 )
 
@@ -171,7 +171,7 @@ func validateProvider(provider string) error {
 	}
 }
 
-func (p *ProjectInfo) NewAdminPlatformInstallCmd() *cobra.Command {
+func (p *ProjectInfo) NewAdminPlatformDeployCmd() *cobra.Command {
 	var o PlatformDeployOptions
 
 	var c = &cobra.Command{

--- a/client-programs/pkg/cmd/admin_platform_install_cmd.go
+++ b/client-programs/pkg/cmd/admin_platform_install_cmd.go
@@ -16,43 +16,43 @@ import (
 var (
 	installExample = `
   # Install educates
-  educates admin cluster install --config config.yaml
+  educates admin platform install --config config.yaml
 
   # Get default configuration for a specific provider
-  educates admin cluster install --provider kind --show-packages-values
+  educates admin platform install --provider kind --show-packages-values
 
   # Get default configuration for a specific provider with provided config file
-  educates admin cluster install --config config.yaml --show-packages-values
+  educates admin platform install --config config.yaml --show-packages-values
 
   # Get deployment descriptors for a specific provider with default config
-  educates admin cluster install --provider kind --dry-run
+  educates admin platform install --provider kind --dry-run
 
   # Get deployment descriptors for a specific provider with provided config
-  educates admin cluster install --config config.yaml --dry-run
+  educates admin platform install --config config.yaml --dry-run
 
   # Install educates with verbose output
-  educates admin cluster install --config config.yaml --verbose
+  educates admin platform install --config config.yaml --verbose
 
   # Install educates without resolving images via kbld (using latest images)
-  educates admin cluster install --config config.yaml --skip-image-resolution
+  educates admin platform install --config config.yaml --skip-image-resolution
 
   # Install educates showing the differences to be applied to the cluster
-  educates admin cluster install --config config.yaml --show-diff
+  educates admin platform install --config config.yaml --show-diff
 
   # Install educates with bundle from different repository
-  educates admin cluster install --config config.yaml --package-repository ghcr.io/jorgemoralespou --version installer-clean
+  educates admin platform install --config config.yaml --package-repository ghcr.io/jorgemoralespou --version installer-clean
 
   # Install educates when locally built
-  educates admin cluster install --config config.yaml  --package-repository localhost:5001 --version 0.0.1
+  educates admin platform install --config config.yaml  --package-repository localhost:5001 --version 0.0.1
 
   # Install educates on a specific cluster
-  educates admin cluster install --config config.yaml --kubeconfig /path/to/kubeconfig --context my-cluster
-  educates admin cluster install --config config.yaml --kubeconfig /path/to/kubeconfig
-  educates admin cluster install --config config.yaml --context my-cluster
+  educates admin platform install --config config.yaml --kubeconfig /path/to/kubeconfig --context my-cluster
+  educates admin platform install --config config.yaml --kubeconfig /path/to/kubeconfig
+  educates admin platform install --config config.yaml --context my-cluster
   `
 )
 
-type AdminInstallOptions struct {
+type PlatformDeployOptions struct {
 	KubeconfigOptions
 	Delete              bool
 	Config              string
@@ -67,7 +67,7 @@ type AdminInstallOptions struct {
 	showDiff            bool
 }
 
-func (o *AdminInstallOptions) Run() error {
+func (o *PlatformDeployOptions) Run() error {
 	fullConfig, err := config.NewInstallationConfigFromFile(o.Config)
 
 	if err != nil {
@@ -171,12 +171,12 @@ func validateProvider(provider string) error {
 	}
 }
 
-func (p *ProjectInfo) NewAdminClusterInstallCmd() *cobra.Command {
-	var o AdminInstallOptions
+func (p *ProjectInfo) NewAdminPlatformInstallCmd() *cobra.Command {
+	var o PlatformDeployOptions
 
 	var c = &cobra.Command{
 		Args:  cobra.NoArgs,
-		Use:   "install",
+		Use:   "deploy",
 		Short: "Install Educates and related cluster services onto your cluster in an imperative manner",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			// We set the default of skipImageResolution to true if ShowPackagesValues is set and the user has not explicitly set it

--- a/client-programs/pkg/cmd/admin_resolver_deploy_cmd.go
+++ b/client-programs/pkg/cmd/admin_resolver_deploy_cmd.go
@@ -19,7 +19,7 @@ func (o *AdminResolverDeployOptions) Run() error {
 	if o.Config != "" {
 		fullConfig, err = config.NewInstallationConfigFromFile(o.Config)
 	} else {
-		fullConfig, err = config.NewDefaultInstallationConfig()
+		fullConfig, err = config.NewInstallationConfigFromUserFile()
 	}
 
 	if err != nil {

--- a/client-programs/pkg/cmd/educates_cmd_group.go
+++ b/client-programs/pkg/cmd/educates_cmd_group.go
@@ -61,7 +61,8 @@ func (p *ProjectInfo) NewEducatesCmdGroup() *cobra.Command {
 			Commands: []*cobra.Command{
 				overrideCommandName(p.NewAdminClusterCreateCmd(), "create-cluster"),
 				overrideCommandName(p.NewAdminClusterDeleteCmd(), "delete-cluster"),
-				overrideCommandName(p.NewAdminPlatformInstallCmd(), "deploy-platform"),
+				overrideCommandName(p.NewAdminPlatformDeployCmd(), "deploy-platform"),
+				overrideCommandName(p.NewAdminPlatformDeleteCmd(), "delete-platform"),
 			},
 		},
 		{

--- a/client-programs/pkg/cmd/educates_cmd_group.go
+++ b/client-programs/pkg/cmd/educates_cmd_group.go
@@ -61,7 +61,7 @@ func (p *ProjectInfo) NewEducatesCmdGroup() *cobra.Command {
 			Commands: []*cobra.Command{
 				overrideCommandName(p.NewAdminClusterCreateCmd(), "create-cluster"),
 				overrideCommandName(p.NewAdminClusterDeleteCmd(), "delete-cluster"),
-				overrideCommandName(p.NewAdminClusterInstallCmd(), "install-cluster"),
+				overrideCommandName(p.NewAdminPlatformInstallCmd(), "deploy-platform"),
 			},
 		},
 		{

--- a/client-programs/pkg/config/installationconfig.go
+++ b/client-programs/pkg/config/installationconfig.go
@@ -152,8 +152,18 @@ type TrainingPortalCredentialsConfig struct {
 	Robot UserCredentialsConfig `yaml:"robot,omitempty"`
 }
 
+type UserClientConfig struct {
+	Id     string `yaml:"id"`
+	Secret string `yaml:"secret"`
+}
+
+type TrainingPortalClientsConfig struct {
+	Robot UserClientConfig `yaml:"robot,omitempty"`
+}
+
 type TrainingPortalConfig struct {
 	Credentials TrainingPortalCredentialsConfig `yaml:"credentials,omitempty"`
+	Clients     TrainingPortalClientsConfig     `yaml:"clients,omitempty"`
 }
 
 type WorkshopSecurityConfig struct {

--- a/client-programs/pkg/config/installationconfig.go
+++ b/client-programs/pkg/config/installationconfig.go
@@ -303,7 +303,7 @@ type EducatesDomainStruct struct {
 	ClusterIngress ClusterIngressConfig `yaml:"clusterIngress,omitempty"`
 }
 
-func newDefaultInstallationConfig() *InstallationConfig {
+func NewDefaultInstallationConfig() *InstallationConfig {
 	return &InstallationConfig{
 		ClusterInfrastructure: ClusterInfrastructureConfig{
 			Provider: "",
@@ -331,7 +331,7 @@ func newDefaultInstallationConfig() *InstallationConfig {
 	}
 }
 
-func NewDefaultInstallationConfig() (*InstallationConfig, error) {
+func NewInstallationConfigFromUserFile() (*InstallationConfig, error) {
 	config := &InstallationConfig{}
 
 	valuesFile := path.Join(utils.GetEducatesHomeDir(), "values.yaml")
@@ -343,7 +343,7 @@ func NewDefaultInstallationConfig() (*InstallationConfig, error) {
 			return nil, errors.Wrapf(err, "unable to parse default config file %s", valuesFile)
 		}
 	} else {
-		config = newDefaultInstallationConfig()
+		config = NewDefaultInstallationConfig()
 	}
 
 	return config, nil

--- a/developer-docs/build-instructions.md
+++ b/developer-docs/build-instructions.md
@@ -113,7 +113,7 @@ See the [Makefile](../Makefile) for more details of the make targets that are av
 Once the container images have been built and pushed to the local docker image registry, you can then deploy everything by running:
 
 ```
-make deploy-installer
+make deploy-platform
 ```
 
 This will perform an install directly from configuration files in the current directory. If needing to test that the `educates-installer` package bundle used by the Educates CLI installer and also `kapp-controller`, is correct, you should instead use the commands:
@@ -121,7 +121,7 @@ This will perform an install directly from configuration files in the current di
 ```
 make push-all-images
 make push-installer-bundle
-make deploy-installer-bundle
+make deploy-platform-bundle
 ```
 
 The `make push-all-images` command will make sure that optional workshop base images as well as the core Educates platform are built. It is necessary to build all images when testing the package bundle as the package generated will include image hashes for all images.
@@ -129,13 +129,13 @@ The `make push-all-images` command will make sure that optional workshop base im
 To delete everything deployed using the `educates-installer` package when using the `make` command, use:
 
 ```
-make delete-installer
+make delete-platform
 ```
 
 or:
 
 ```
-make delete-installer-bundle
+make delete-platform-bundle
 ```
 
 as appropriate.


### PR DESCRIPTION
Portal credentials/clients settings not passed through.

fixes https://github.com/vmware-tanzu-labs/educates-training-platform/issues/421
fixes https://github.com/vmware-tanzu-labs/educates-training-platform/issues/422

Change naming for CLI platform deployment commands/aliases, as well as makefile targets when building locally.

closes https://github.com/vmware-tanzu-labs/educates-training-platform/issues/424

Add distinct platform delete command.

closes https://github.com/vmware-tanzu-labs/educates-training-platform/issues/425