### PR TITLE
Missing changeOrigin property for ingresses in Workshop CRD.

### DIFF
--- a/carvel-packages/installer/bundle/config/ytt/_ytt_lib/packages/educates/11-session-manager/01-crds-workshop.yaml
+++ b/carvel-packages/installer/bundle/config/ytt/_ytt_lib/packages/educates/11-session-manager/01-crds-workshop.yaml
@@ -1061,6 +1061,8 @@ spec:
                             type: string
                           port:
                             type: integer
+                          changeOrigin:
+                            type: boolean
                           headers:
                             type: array
                             items:

--- a/project-docs/release-notes/version-3.0.0.md
+++ b/project-docs/release-notes/version-3.0.0.md
@@ -36,3 +36,7 @@ Bugs Fixed
 
 * Theme overrides were not being applied to access control pages of the
   training portal.
+
+* The `changeOrigin` property was missing from the `Workshop` custom resource
+  defintion for `ingresses` even though was documented as something that could
+  be set.


### PR DESCRIPTION
fixes https://github.com/vmware-tanzu-labs/educates-training-platform/issues/442