### PR TITLE
Must still consume output when not verbose flag else image pull doesn't run.

### DIFF
--- a/client-programs/pkg/cmd/admin_cluster_create_cmd.go
+++ b/client-programs/pkg/cmd/admin_cluster_create_cmd.go
@@ -304,8 +304,11 @@ func checkPortAvailability(listenAddress string, ports []uint, verbose bool) (bo
 	}
 
 	defer reader.Close()
+
 	if verbose {
 		io.Copy(os.Stdout, reader)
+	} else {
+		io.Copy(io.Discard, reader)
 	}
 
 	if listenAddress == "" {


### PR DESCRIPTION
fixes https://github.com/vmware-tanzu-labs/educates-training-platform/issues/452