### PR TITLE
Local secrets enabled when no config

### DIFF
--- a/client-programs/pkg/cmd/admin_cluster_create_cmd.go
+++ b/client-programs/pkg/cmd/admin_cluster_create_cmd.go
@@ -217,10 +217,16 @@ func (p *ProjectInfo) NewAdminClusterCreateCmd() *cobra.Command {
 	var o AdminClusterCreateOptions
 
 	var c = &cobra.Command{
-		Args:    cobra.NoArgs,
-		Use:     "create",
-		Short:   "Creates a local Kubernetes cluster",
-		RunE:    func(_ *cobra.Command, _ []string) error { return o.Run() },
+		Args:  cobra.NoArgs,
+		Use:   "create",
+		Short: "Creates a local Kubernetes cluster",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			// We set the default of skipImageResolution to true if ShowPackagesValues is set and the user has not explicitly set it
+			if o.Config == "" && !cmd.Flags().Changed("with-local-secrets") {
+				o.WithLocalSecrets = true
+			}
+			return o.Run()
+		},
 		Example: createExample,
 	}
 

--- a/client-programs/pkg/cmd/admin_cluster_create_cmd.go
+++ b/client-programs/pkg/cmd/admin_cluster_create_cmd.go
@@ -221,7 +221,7 @@ func (p *ProjectInfo) NewAdminClusterCreateCmd() *cobra.Command {
 		Use:   "create",
 		Short: "Creates a local Kubernetes cluster",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			// We set the default of skipImageResolution to true if ShowPackagesValues is set and the user has not explicitly set it
+			// We set the default of withLocalSecrets to true if config is not provided and the user has not explicitly set it
 			if o.Config == "" && !cmd.Flags().Changed("with-local-secrets") {
 				o.WithLocalSecrets = true
 			}

--- a/client-programs/pkg/cmd/admin_config_view_cmd.go
+++ b/client-programs/pkg/cmd/admin_config_view_cmd.go
@@ -69,7 +69,13 @@ func (p *ProjectInfo) NewAdminConfigViewCmd() *cobra.Command {
 		Args:  cobra.NoArgs,
 		Use:   "view",
 		Short: "View complete configuration",
-		RunE:  func(_ *cobra.Command, _ []string) error { return o.Run() },
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			// We set the default of withLocalSecrets to true if config is not provided and the user has not explicitly set it
+			if o.Config == "" && !cmd.Flags().Changed("with-local-secrets") {
+				o.WithLocalSecrets = true
+			}
+			return o.Run()
+		},
 	}
 
 	c.Flags().StringVar(


### PR DESCRIPTION
By default if the user has not explicitly set --with-local-secrets with any value and config is not provided, it will enable local-secrets feature for create-cluster command.
Closes #432 