### PR TITLE
Adding .gitignore to workshop templates

### DIFF
--- a/client-programs/pkg/templates/files/hugo/.gitignore
+++ b/client-programs/pkg/templates/files/hugo/.gitignore
@@ -1,0 +1,2 @@
+workshop/.hugo_build.lock
+workshop/public

--- a/client-programs/pkg/templates/internal.go
+++ b/client-programs/pkg/templates/internal.go
@@ -11,7 +11,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-//go:embed files/*
+//go:embed all:files/*
 var workshopTemplates embed.FS
 
 type InternalTemplate string


### PR DESCRIPTION
Fixes #429 

Adding a .gitignore file to the top of the template (Only for hugo since classic don't create these files anyways) works for when the workshop directory is top level git repo or when it's included in multiworkshop repo.