### PR TITLE
Adding bind-ip to registry

### DIFF
--- a/client-programs/pkg/cmd/local_registry_deploy_cmd.go
+++ b/client-programs/pkg/cmd/local_registry_deploy_cmd.go
@@ -32,7 +32,12 @@ func (o *LocalRegistryDeployOptions) Run() error {
 		fmt.Println("Warning: Kubernetes cluster not linked to image registry.")
 	}
 
-	clusterConfig := cluster.NewClusterConfig(o.Kubeconfig, o.Context)
+	clusterConfig, err := cluster.NewClusterConfigIfAvailable(o.Kubeconfig, o.Context)
+
+	if err != nil {
+		fmt.Println("Warning: Kubernetes cluster not available")
+		return nil
+	}
 
 	client, err := clusterConfig.GetClient()
 


### PR DESCRIPTION
Fixes #162 
Fixes #163 

`educates local registry create` and `educates admin cluster create` now have the option to provide a bindIP for the registry.

This can be an IP or a name, but Docker needs to be able to bind to that IP given the networking configuration, so mostly only works with 127.0.0.1 which is the default or 0.0.0.0.  Any other IP, or domain that resolves to an IP, might not work if Docker 