### PR TITLE
Actions node 20

### DIFF
--- a/.github/workflows/build-and-publish-images.yaml
+++ b/.github/workflows/build-and-publish-images.yaml
@@ -118,7 +118,7 @@ jobs:
           registry: ghcr.io
 
       - name: Build and push ${{matrix.image}} image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: ${{matrix.image}}
           platforms: ${{env.TARGET_PLATFORMS}}
@@ -130,7 +130,7 @@ jobs:
 
       - name: Cache build ${{matrix.image}} (amd64)
         if: contains(env.TARGET_PLATFORMS, 'linux/amd64')
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: ${{matrix.image}}
           platforms: linux/amd64
@@ -140,7 +140,7 @@ jobs:
 
       - name: Cache build ${{matrix.image}} (arm64)
         if: contains(env.TARGET_PLATFORMS, 'linux/arm64')
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: ${{matrix.image}}
           platforms: linux/arm64
@@ -261,7 +261,7 @@ jobs:
           registry: ghcr.io
 
       - name: Build and push base-environment image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: workshop-images/base-environment
           platforms: ${{env.TARGET_PLATFORMS}}
@@ -273,7 +273,7 @@ jobs:
 
       - name: Cache build ${{matrix.image}} (amd64)
         if: contains(env.TARGET_PLATFORMS, 'linux/amd64')
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: workshop-images/base-environment
           platforms: linux/amd64
@@ -287,7 +287,7 @@ jobs:
 
       - name: Cache build ${{matrix.image}} (arm64)
         if: contains(env.TARGET_PLATFORMS, 'linux/arm64')
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: workshop-images/base-environment
           platforms: linux/arm64
@@ -419,7 +419,7 @@ jobs:
           registry: ghcr.io
 
       - name: Build and push ${{matrix.image}} image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: workshop-images/${{matrix.image}}
           platforms: ${{env.TARGET_PLATFORMS}}
@@ -435,7 +435,7 @@ jobs:
 
       - name: Cache build ${{matrix.image}} (amd64)
         if: contains(env.TARGET_PLATFORMS, 'linux/amd64')
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: workshop-images/${{matrix.image}}
           platforms: linux/amd64
@@ -453,7 +453,7 @@ jobs:
 
       - name: Cache build ${{matrix.image}} (arm64)
         if: contains(env.TARGET_PLATFORMS, 'linux/arm64')
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: workshop-images/${{matrix.image}}
           platforms: linux/arm64
@@ -868,7 +868,7 @@ jobs:
           echo "REPOSITORY_TAG=${GITHUB_REF##*/}" >>${GITHUB_ENV}
 
       - name: Build and push docker-extension image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: docker-extension
           platforms: ${{env.TARGET_PLATFORMS}}
@@ -960,7 +960,7 @@ jobs:
 
       - name: Create release
         id: create_release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:
@@ -1011,7 +1011,7 @@ jobs:
 
       - name: Create pull request for package repository files
         if: ${{ (env.IS_FORK == 'false') && (env.PRERELEASE == 'false') }}
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v6
         with:
           add-paths: |
             package-repository

--- a/.github/workflows/build-and-publish-images.yaml
+++ b/.github/workflows/build-and-publish-images.yaml
@@ -25,6 +25,9 @@ jobs:
   publish-generic-images:
     name: Publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     strategy:
       fail-fast: false
@@ -170,6 +173,9 @@ jobs:
   publish-workshop-base-image:
     name: Publish (base-environment)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: Check out the repository
@@ -314,6 +320,9 @@ jobs:
   publish-workshop-images:
     name: Publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     needs:
       - publish-workshop-base-image
 
@@ -487,6 +496,9 @@ jobs:
   publish-carvel-bundles:
     name: Bundle
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     needs:
       - publish-generic-images
       - publish-workshop-images
@@ -614,6 +626,9 @@ jobs:
   build-client-programs-linux-amd64:
     name: Build (clients) / amd64@linux
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: Check out the repository
@@ -651,6 +666,9 @@ jobs:
   build-client-programs-linux-arm64:
     name: Build (clients) / arm64@linux
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: Check out the repository
@@ -688,6 +706,9 @@ jobs:
   build-client-programs-darwin-amd64:
     name: Build (clients) / amd64@darwin
     runs-on: macos-12
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: Check out the repository
@@ -730,6 +751,9 @@ jobs:
   build-client-programs-darwin-arm64:
     name: Build (clients) / arm64@darwin
     runs-on: macos-12
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: Check out the repository
@@ -767,6 +791,9 @@ jobs:
   publish-client-programs:
     name: Programs
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     needs:
       - build-client-programs-linux-amd64
       - build-client-programs-linux-arm64
@@ -822,6 +849,9 @@ jobs:
   publish-docker-extension:
     name: Extension
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     needs:
       - publish-client-programs
 
@@ -881,6 +911,9 @@ jobs:
   release-artifacts:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     if: startsWith(github.ref, 'refs/tags/')
     needs:
       - publish-carvel-bundles
@@ -981,6 +1014,9 @@ jobs:
   commit-packages:
     name: Commit
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     if: startsWith(github.ref, 'refs/tags/')
     needs:
       - release-artifacts

--- a/.github/workflows/build-and-publish-images.yaml
+++ b/.github/workflows/build-and-publish-images.yaml
@@ -25,9 +25,6 @@ jobs:
   publish-generic-images:
     name: Publish
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
 
     strategy:
       fail-fast: false
@@ -173,9 +170,6 @@ jobs:
   publish-workshop-base-image:
     name: Publish (base-environment)
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
 
     steps:
       - name: Check out the repository
@@ -320,9 +314,6 @@ jobs:
   publish-workshop-images:
     name: Publish
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
     needs:
       - publish-workshop-base-image
 
@@ -496,9 +487,6 @@ jobs:
   publish-carvel-bundles:
     name: Bundle
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
     needs:
       - publish-generic-images
       - publish-workshop-images
@@ -626,9 +614,6 @@ jobs:
   build-client-programs-linux-amd64:
     name: Build (clients) / amd64@linux
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
 
     steps:
       - name: Check out the repository
@@ -666,9 +651,6 @@ jobs:
   build-client-programs-linux-arm64:
     name: Build (clients) / arm64@linux
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
 
     steps:
       - name: Check out the repository
@@ -706,9 +688,6 @@ jobs:
   build-client-programs-darwin-amd64:
     name: Build (clients) / amd64@darwin
     runs-on: macos-12
-    permissions:
-      contents: read
-      packages: write
 
     steps:
       - name: Check out the repository
@@ -751,9 +730,6 @@ jobs:
   build-client-programs-darwin-arm64:
     name: Build (clients) / arm64@darwin
     runs-on: macos-12
-    permissions:
-      contents: read
-      packages: write
 
     steps:
       - name: Check out the repository
@@ -791,9 +767,6 @@ jobs:
   publish-client-programs:
     name: Programs
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
     needs:
       - build-client-programs-linux-amd64
       - build-client-programs-linux-arm64
@@ -849,9 +822,6 @@ jobs:
   publish-docker-extension:
     name: Extension
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
     needs:
       - publish-client-programs
 
@@ -911,9 +881,6 @@ jobs:
   release-artifacts:
     name: Release
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
     if: startsWith(github.ref, 'refs/tags/')
     needs:
       - publish-carvel-bundles
@@ -1014,9 +981,6 @@ jobs:
   commit-packages:
     name: Commit
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
     if: startsWith(github.ref, 'refs/tags/')
     needs:
       - release-artifacts


### PR DESCRIPTION
Upgraded github actions in our workflow to use versions with node-20 and not node-16 which is no longer supported.

Closes #387 

Squash when merging.