### PR TITLE
Fixing default HTTP versions in contour

### DIFF
--- a/carvel-packages/installer/bundle/config/ytt/_ytt_lib/packages/contour/overlays/overlay-contour.yaml
+++ b/carvel-packages/installer/bundle/config/ytt/_ytt_lib/packages/contour/overlays/overlay-contour.yaml
@@ -1,6 +1,7 @@
 #@ load("@ytt:overlay", "overlay")
 #@ load("@ytt:data", "data")
 #@ load("@ytt:yaml", "yaml")
+#@ load("/rules.star", "default_HTTP_Versions")
 
 #@ def contour_config():
 incluster: true
@@ -11,8 +12,7 @@ tls:
     namespace: #@ data.values.namespace
   envoy-client-certificate:
 accesslog-format: envoy
-#@ if/end data.values.configFileContents.defaultHttpVersions:
-default-http-versions: #@ data.values.configFileContents.defaultHttpVersions
+default-http-versions: #@ data.values.configFileContents.defaultHttpVersions or default_HTTP_Versions()
 #@ end
 
 #@ if/end hasattr(data.values, "contour") and data.values.contour != None:

--- a/carvel-packages/installer/bundle/config/ytt/_ytt_lib/packages/contour/rules.star
+++ b/carvel-packages/installer/bundle/config/ytt/_ytt_lib/packages/contour/rules.star
@@ -18,3 +18,7 @@ end
 def check_all(val):
   return check_infra(val) and check_host_ports(val)
 end
+
+def default_HTTP_Versions():
+  return ["HTTP/1.1", "HTTP/2"]
+end

--- a/carvel-packages/installer/bundle/config/ytt/_ytt_lib/packages/contour/values-schema.yaml
+++ b/carvel-packages/installer/bundle/config/ytt/_ytt_lib/packages/contour/values-schema.yaml
@@ -31,6 +31,5 @@ externaldns:
 
 #@schema/desc "Configuration for the Contour ingress controller"
 configFileContents:
-  #@schema/default ["HTTP/1.1", "HTTP/2"]
   defaultHttpVersions:
     - ""

--- a/carvel-packages/installer/scenarios/kind/test-kind-scenario-13/description.md
+++ b/carvel-packages/installer/scenarios/kind/test-kind-scenario-13/description.md
@@ -1,0 +1,2 @@
+kind using customized contour config en kapp-controller enabled
+(Contour config would be defaulted and provided will not be used)

--- a/carvel-packages/installer/scenarios/kind/test-kind-scenario-13/expected.yaml
+++ b/carvel-packages/installer/scenarios/kind/test-kind-scenario-13/expected.yaml
@@ -1,0 +1,37 @@
+clusterPackages:
+  contour:
+    enabled: true
+    settings:
+      infraProvider: kind
+      contour:
+        replicas: 1
+      configFileContents:
+        defaultHttpVersions:
+          - HTTP/1.1
+      service:
+        type: ClusterIP
+        useHostPorts: true
+  cert-manager:
+    enabled: false
+    settings: {}
+  external-dns:
+    enabled: false
+    settings: {}
+  certs:
+    enabled: false
+    settings: {}
+  kyverno:
+    enabled: true
+    settings: {}
+  kapp-controller:
+    enabled: true
+    settings: {}
+  educates:
+    enabled: true
+    settings:
+      clusterIngress:
+        domain: educates.example.com
+      clusterSecurity:
+        policyEngine: kyverno
+      workshopSecurity:
+        rulesEngine: kyverno

--- a/carvel-packages/installer/scenarios/kind/test-kind-scenario-13/values.yaml
+++ b/carvel-packages/installer/scenarios/kind/test-kind-scenario-13/values.yaml
@@ -1,0 +1,16 @@
+---
+clusterInfrastructure:
+  provider: "kind"
+clusterPackages:
+  contour:
+    enabled: true
+    settings:
+      configFileContents:
+        defaultHttpVersions:
+          - "HTTP/1.1"
+  kapp-controller:
+    enabled: true
+clusterSecurity:
+  policyEngine: "kyverno"
+clusterIngress:
+  domain: "educates.example.com"

--- a/carvel-packages/installer/scenarios/test-scenarios.sh
+++ b/carvel-packages/installer/scenarios/test-scenarios.sh
@@ -76,10 +76,10 @@ function test {
     echo "==="
     cat description.md
     echo "==="
-    # RESULT_VALUES=$(ytt --data-values-file values.yaml -f ${DIR}/../bundle/config/ytt --data-value-yaml debug=false | yq)
-    # diff <(echo "$RESULT_VALUES") <(cat expected.yaml | yq)
-    # result=$?
-    # [[ "$result" -eq 0 ]] && echo "Result Diff Values/Expected: OK" || echo -e "Result Diff Values/Expected: ${RED}NO OK${NC}"
+    RESULT_VALUES=$(ytt --data-values-file values.yaml -f ${DIR}/../bundle/config/ytt --data-value-yaml debug=true | yq)
+    diff <(echo "$RESULT_VALUES") <(cat expected.yaml | yq)
+    result=$?
+    [[ "$result" -eq 0 ]] && echo "Result Diff Values/Expected: OK" || echo -e "Result Diff Values/Expected: ${RED}NO OK${NC}"
     ytt --data-values-file values.yaml -f ${DIR}/../bundle/config/ytt --data-value-yaml debug=false >/dev/null 2>&1
     result=$?
     [[ "$result" -eq 0 ]] && echo "Result ytt processing: OK" || echo -e "Result ytt processing: ${RED}NO OK${NC}"


### PR DESCRIPTION
Fixes #510 

Since there's a problem when calling ytt with default schema and values in a `data/values` file as mentioned in [this thread](https://kubernetes.slack.com/archives/CH8KCCKA5/p1721036012274939), we extracted the defaults from the schema into a function of the overlay.