### PR TITLE
Record session user when allocating session.

### DIFF
--- a/carvel-packages/installer/bundle/config/ytt/_ytt_lib/packages/educates/11-session-manager/01-crds-workshopallocation.yaml
+++ b/carvel-packages/installer/bundle/config/ytt/_ytt_lib/packages/educates/11-session-manager/01-crds-workshopallocation.yaml
@@ -40,8 +40,11 @@ spec:
                   type: object
                   required:
                   - name
+                  - user
                   properties:
                     name:
+                      type: string
+                    user:
                       type: string
             status:
               type: object

--- a/carvel-packages/installer/bundle/config/ytt/_ytt_lib/packages/educates/11-session-manager/01-crds-workshopsession.yaml
+++ b/carvel-packages/installer/bundle/config/ytt/_ytt_lib/packages/educates/11-session-manager/01-crds-workshopsession.yaml
@@ -151,6 +151,8 @@ spec:
                           properties:
                             enabled:
                               type: boolean
+                    user:
+                      type: string
       additionalPrinterColumns:
       - name: URL
         type: string

--- a/project-docs/release-notes/version-3.0.0.md
+++ b/project-docs/release-notes/version-3.0.0.md
@@ -99,3 +99,8 @@ Bugs Fixed
 * Fixes a timing issue where the `phase` recorded against a `WorkshopSession`
   resource created by a training portal, would revert to `Available` rather than
   being set to be `Allocated`.
+
+* An attempt to reacquire a workshop session for a user via the REST API which
+  had not been created via the REST API but by the web interface would result in
+  an internal error. Now properly disallow the request for this case and return
+  an error saying session cannot be reacquired.

--- a/project-docs/release-notes/version-3.0.0.md
+++ b/project-docs/release-notes/version-3.0.0.md
@@ -24,6 +24,10 @@ New Features
   when setting headers for a session ingress proxy. This is also available as an
   environment variable in a workshop session as the variable `GIT_AUTH_TOKEN`.
 
+* The identifier for the user to which a workshop session is allocated is now
+  recorded in the status of the `WorkshopSession` resource, as well as in the
+  `WorkshopAllocation` resource.
+
 Features Changed
 ----------------
 
@@ -91,3 +95,7 @@ Bugs Fixed
 
 * The `educates local config edit` command would fail if run prior to having
   ever created a local Educates cluster as the config directory would not exist.
+
+* Fixes a timing issue where the `phase` recorded against a `WorkshopSession`
+  resource created by a training portal, would revert to `Available` rather than
+  being set to be `Allocated`.

--- a/training-portal/src/project/apps/workshops/manager/sessions.py
+++ b/training-portal/src/project/apps/workshops/manager/sessions.py
@@ -137,7 +137,7 @@ def create_request_resources(session):
     )
 
 
-def update_session_status(name, phase, user=""):
+def update_session_status(name, phase, user=None):
     """Update the status of the Kubernetes resource object for the workshop
     session.
 
@@ -161,7 +161,7 @@ def update_session_status(name, phase, user=""):
         status["phase"] = phase
 
         if user:
-            status["user"] = user
+            status["user"] = str(user.username)
 
         resource.update()
 
@@ -170,7 +170,7 @@ def update_session_status(name, phase, user=""):
                 "Updated status of workshop session %s to %s for user %s.",
                 name,
                 phase,
-                user,
+                user.username,
             )
         else:
             logger.info("Updated status of workshop session %s to %s.", name, phase)
@@ -314,7 +314,7 @@ def create_workshop_session(session, secret):
     report_analytics_event(session, "Session/Created")
 
     if session.owner:
-        update_session_status(session.name, "Allocated", session.owner.username)
+        update_session_status(session.name, "Allocated", session.owner)
         report_analytics_event(session, "Session/Started")
         if session.token:
             session.mark_as_waiting()
@@ -691,11 +691,11 @@ def allocate_session_for_user(environment, user, token, timeout=None, params={})
     session.params = resolve_request_params(session.environment.workshop, params)
 
     if token:
-        update_session_status(session.name, "Allocating", user.username)
+        update_session_status(session.name, "Allocating", user)
         report_analytics_event(session, "Session/Pending")
         session.mark_as_pending(user, token, timeout)
     else:
-        update_session_status(session.name, "Allocated", user.username)
+        update_session_status(session.name, "Allocated", user)
         report_analytics_event(session, "Session/Started")
         session.mark_as_running(user)
 
@@ -738,9 +738,9 @@ def create_session_for_user(environment, user, token, timeout=None, params={}):
         session.params = resolve_request_params(session.environment.workshop, params)
 
         if token:
-            update_session_status(session.name, "Allocating", user.username)
+            update_session_status(session.name, "Allocating", user)
         else:
-            update_session_status(session.name, "Allocated", user.username)
+            update_session_status(session.name, "Allocated", user)
 
         session.mark_as_pending(user, token, timeout)
 
@@ -767,9 +767,9 @@ def create_session_for_user(environment, user, token, timeout=None, params={}):
         session.params = resolve_request_params(session.environment.workshop, params)
 
         if token:
-            update_session_status(session.name, "Allocating", user.username)
+            update_session_status(session.name, "Allocating", user)
         else:
-            update_session_status(session.name, "Allocated", user.username)
+            update_session_status(session.name, "Allocated", user)
 
         session.mark_as_pending(user, token, timeout)
 
@@ -803,9 +803,9 @@ def create_session_for_user(environment, user, token, timeout=None, params={}):
     session.params = resolve_request_params(session.environment.workshop, params)
 
     if token:
-        update_session_status(session.name, "Allocating", user.username)
+        update_session_status(session.name, "Allocating", user)
     else:
-        update_session_status(session.name, "Allocated", user.username)
+        update_session_status(session.name, "Allocated", user)
 
     session.mark_as_pending(user, token, timeout)
 

--- a/training-portal/src/project/apps/workshops/views/environment.py
+++ b/training-portal/src/project/apps/workshops/views/environment.py
@@ -378,6 +378,13 @@ def environment_request(request, name):
     if not session:
         return JsonResponse({"error": "No session available"}, status=503)
 
+    # If there is a session but it doesn't have a token associated with it then
+    # it wasn't created via the REST API and so cannot be reacquired using the
+    # REST API.
+
+    if session and not session.token:
+        return JsonResponse({"error": "Cannot be reacquired"}, status=503)
+
     details = {}
 
     details["name"] = session.name

--- a/training-portal/src/project/apps/workshops/views/session.py
+++ b/training-portal/src/project/apps/workshops/views/session.py
@@ -140,7 +140,7 @@ def session_activate(request, name):
         return HttpResponseServerError("Owner for session is not active")
 
     if not instance.is_running():
-        update_session_status(instance.name, "Allocated")
+        update_session_status(instance.name, "Allocated", session.owner.name)
         report_analytics_event(instance, "Session/Started")
         instance.mark_as_running()
 

--- a/training-portal/src/project/apps/workshops/views/session.py
+++ b/training-portal/src/project/apps/workshops/views/session.py
@@ -140,7 +140,7 @@ def session_activate(request, name):
         return HttpResponseServerError("Owner for session is not active")
 
     if not instance.is_running():
-        update_session_status(instance.name, "Allocated", session.owner.name)
+        update_session_status(instance.name, "Allocated", session.owner)
         report_analytics_event(instance, "Session/Started")
         instance.mark_as_running()
 


### PR DESCRIPTION
Fix incorrect status being left on workshop session.

fixes https://github.com/vmware-tanzu-labs/educates-training-platform/issues/515

Fix internal error when try to acquire session not created via REST API.

fixes https://github.com/vmware-tanzu-labs/educates-training-platform/issues/503

As well as fixing linked issues, add session user against status of `WorkshopSession`, and in `WorkshopAllocation`, to allow easier tracking of malicious users, and make it easier to determine when user has an existing workshop session when a workshop request is being handled by a lookup service.

