### PR TITLE
Workshop session request.

### DIFF
--- a/project-docs/portal-rest-api/session-management.md
+++ b/project-docs/portal-rest-api/session-management.md
@@ -84,7 +84,7 @@ curl -H "Authorization: Bearer <access-token>" https://lab-markdown-sample-ui.te
 
 If the supplied ID matches a user in the training portal, it will be used internally by the training portal, and the same value will be returned for ``user`` in the response.
 
-When the user does match, if there is already a workshop session allocated to the user for the workshop environment the request is made against, a link to the existing workshop session will be returned rather than creating a new workshop session.
+When the user does match, if there is already a workshop session allocated to the user for the workshop environment the request is made against, a link to the existing workshop session will be returned rather than creating a new workshop session, although if no existing session is found, a new workshop session will still be created if there is capacity. If you would rather a new workshop session not be created and want to guarantee that only the existing workshop session is returned, you need to remember the name of the prior session and supply it along with the ``user`` value as the ``session`` param.
 
 Where the front end using the REST API has it's own globally unique concept of a user ID, it can supply it using the ``user`` param in all requests. When this is done, rather than the training portal generating a user identifier the supplied identifier will be used instead. In this case the ``user`` parameter returned with the response will always match that supplied with the request.
 

--- a/project-docs/release-notes/version-3.0.0.md
+++ b/project-docs/release-notes/version-3.0.0.md
@@ -28,6 +28,16 @@ New Features
   recorded in the status of the `WorkshopSession` resource, as well as in the
   `WorkshopAllocation` resource.
 
+* When requesting a workshop session via the REST API, if the `session` param is
+  supplied along with `user` then an existing workshop session for the user will
+  only be returned if the name of that session also matches that supplied. When
+  `session` is supplied in this way, a new workshop session will never be
+  created and the response will indicate no session is available instead if no
+  existing workshop session is found. To make use of this any front end would
+  have to remember the prior session name, or otherwise first discover the name
+  of the existing workshop session by looking up via the REST API, sessions
+  which are active for the user.
+
 Features Changed
 ----------------
 


### PR DESCRIPTION
This provides a way when requesting a workshop session via the REST API, that if an existing workshop session exists for a user, that it must have a matching session name to what is supplied. This is to ensure you get back the session you wanted and that a new workshop session is not created instead.

Reason for this is that in lookup service you want to see if can pickup an existing workshop session first, but you don't necessarily want a new workshop session created automatically if existing workshop session not found. This is because you may need to actually request a new workshop session from a different cluster if the first cluster was marked as disabled for new sessions due to being shutdown.