### PR TITLE
Fixing external-dns config for route53

### DIFF
--- a/carvel-packages/installer/bundle/config/ytt/_ytt_lib/packages/external-dns/overlays/defaults.star
+++ b/carvel-packages/installer/bundle/config/ytt/_ytt_lib/packages/external-dns/overlays/defaults.star
@@ -4,12 +4,14 @@ def get_default_aws_args():
   args = [
     "--provider=aws",
     "--source=service",
-    "--source=ingress",
-    "--source=contour-httpproxy",
     "--aws-prefer-cname",
+    "--aws-zone-match-parent",
     "--registry=txt",
     "--txt-prefix=txt",
   ]
+  #! These are removed as in AWS we just need the wildcard for the envoy service
+  #!  "--source=ingress",
+  #!  "--source=contour-httpproxy",
 
   if hasattr(data.values.aws, "args"):
     if data.values.aws.args.zone_type:

--- a/carvel-packages/installer/bundle/config/ytt/_ytt_lib/packages/external-dns/values-schema.yaml
+++ b/carvel-packages/installer/bundle/config/ytt/_ytt_lib/packages/external-dns/values-schema.yaml
@@ -90,9 +90,9 @@ aws:
     secretKey: ""
   args:
     zone_type: "public"
-    policy: "upsert-only"
+    policy: "sync"
     domain_filter: ""
-    txt_owner_id: "k8s"
+    txt_owner_id: "educates"
 
 #@schema/desc "Azure configuration. Package will create azure.json Secret, Volume, and VolumeMount with supplied values."
 #@schema/nullable
@@ -131,6 +131,6 @@ gcp:
   args:
     project: ""
     zone_visibility: "public"
-    policy: "upsert-only"
+    policy: "sync"
     domain_filter: ""
-    txt_owner_id: "k8s"
+    txt_owner_id: "educates"

--- a/client-programs/pkg/config/installationconfig.go
+++ b/client-programs/pkg/config/installationconfig.go
@@ -40,8 +40,13 @@ type AwsClusterInfrastructureIRSARolesConfig struct {
 type AwsClusterInfrastructureConfig struct {
 	AwsId       string                                  `yaml:"awsId,omitempty"`
 	Region      string                                  `yaml:"region"`
+	Route53Zone Route53ZoneConfig                       `yaml:"route53,omitempty"`
 	ClusterName string                                  `yaml:"clusterName,omitempty"`
 	IRSARoles   AwsClusterInfrastructureIRSARolesConfig `yaml:"irsaRoles,omitempty"`
+}
+
+type Route53ZoneConfig struct {
+	HostedZoneId string `yaml:"hostedZone"`
 }
 
 type GcpClusterInfrastructureWorkloadIdentitiesConfig struct {


### PR DESCRIPTION
This changes the behaviour of external-dns with relation to Route53, as it changed upstream in version [0.13.6](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.13.6) (https://github.com/kubernetes-sigs/external-dns/pull/3695)

This PR will:
- Only apply to services as we do set an annotation on the envoy service for wildcard domain, and that's the only one needed
- Add `--aws-zone-match-parent` to support back match parents as fixed by https://github.com/kubernetes-sigs/external-dns/pull/4236 in [0.14.1](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.14.1)
- Changed `--policy` to `sync` so that txt and CNAMEs are deleted on uninstall. Previously we had `upsert-only` which left the records there.

Fixes #535