### PR TITLE
Revert to upsert-only for extenal-dns policy.

### DIFF
--- a/carvel-packages/installer/bundle/config/ytt/_ytt_lib/packages/external-dns/values-schema.yaml
+++ b/carvel-packages/installer/bundle/config/ytt/_ytt_lib/packages/external-dns/values-schema.yaml
@@ -90,7 +90,7 @@ aws:
     secretKey: ""
   args:
     zone_type: "public"
-    policy: "sync"
+    policy: "upsert-only"
     domain_filter: ""
     txt_owner_id: "educates"
 
@@ -131,6 +131,6 @@ gcp:
   args:
     project: ""
     zone_visibility: "public"
-    policy: "sync"
+    policy: "upsert-only"
     domain_filter: ""
     txt_owner_id: "educates"


### PR DESCRIPTION
Reverts setting for policy as described in https://github.com/vmware-tanzu-labs/educates-training-platform/issues/545