### PR TITLE
Lookup existing session.

### DIFF
--- a/project-docs/release-notes/version-3.0.1.md
+++ b/project-docs/release-notes/version-3.0.1.md
@@ -8,6 +8,25 @@ For details on significant changes in future versions, including feature
 deprecations and removals which may necessitate updates to existing workshops,
 see [Upcoming changes](upcoming-changes).
 
+Features Changed
+----------------
+
+* When requesting a workshop session using the lookup service, a search for an
+  existing session for that workshop and user is now made against all training
+  portals across all clusters. This is done before filtering out what training
+  portals are accessible to a tenant. This is done so an existing workshop
+  session is found even if labels for clusters or portals had been changed such
+  that the training portal is no longer mapped to the tenant. Such changes to
+  labels may have been made to prevent creation of new workshop sessions against
+  a cluster or training portal when rolling over to a new cluster and waiting
+  for existing workshop sessions on the old cluster to expire. Note that this
+  relies on client side user IDs to be unique across all tenants hosted by the
+  clusters the lookup service monitors. If a single lookup service is being used
+  by multiple distinct custom front end web portals and it is possible the same
+  user ID could be used by more than one front end, it is recommended that the
+  front end incorporate the tenant name as part of the client side user ID
+  passed to the lookup service.
+
 Bugs Fixed
 ----------
 


### PR DESCRIPTION
This change allows an existing workshop session to be found by the lookup service even where label selectors for a tenant were changed such that existing cluster/portal was no longer accessing to the tenant.