### PR TITLE
Sync external-dns hostedzone record changes

### DIFF
--- a/carvel-packages/installer/bundle/config/ytt/_ytt_lib/infrastructure/eks/10-default-settings-for-provider.yaml
+++ b/carvel-packages/installer/bundle/config/ytt/_ytt_lib/infrastructure/eks/10-default-settings-for-provider.yaml
@@ -49,7 +49,8 @@ clusterPackages:
       aws:
         args:
           domain_filter: #@ data.values.clusterInfrastructure.aws.route53.hostedZone if hasattr(data.values.clusterInfrastructure.aws.route53, "hostedZone") else data.values.clusterIngress.domain
-          txt_owner_id: "educates"
+          txt_owner_id: #@ data.values.clusterIngress.domain
+          policy: sync
   certs:
     enabled: #@ isClusterPackageEnableByDefault("certs")
     settings:

--- a/carvel-packages/installer/bundle/config/ytt/_ytt_lib/infrastructure/gke/10-default-settings-for-provider.yaml
+++ b/carvel-packages/installer/bundle/config/ytt/_ytt_lib/infrastructure/gke/10-default-settings-for-provider.yaml
@@ -49,7 +49,8 @@ clusterPackages:
         args:
           project: #@ data.values.clusterInfrastructure.gcp.project
           domain_filter: #@ data.values.clusterInfrastructure.gcp.cloudDNS.zone if hasattr(data.values.clusterInfrastructure.gcp.cloudDNS, "zone") else data.values.clusterIngress.domain
-          txt_owner_id: "educates"
+          txt_owner_id: #@ data.values.clusterIngress.domain
+          policy: sync
   certs:
     enabled: #@ isClusterPackageEnableByDefault("certs")
     settings:


### PR DESCRIPTION
Adding a unique `txt_owner_id` allows for no collision of records in Route53 hostedZones so that sync can be used.

As in Route53 we have a configuration of `--aws-zone-match-parent` if there's multiple hostedZones for toplevel domains, record will be created in the first one found as traversing the structure from longer to shorter.

e.g. if there's a hosted zone for `labs.example.com` and another one for `example.com` if we create a cluster with name `cluster.labs.example.com` the record will be created in `labs.example.com`. If this zone didn't exist, it would use `example.com` zone. If we want to explicitly create the record in any zone, we can use the config value `clusterInfrastructure.aws.route53.hostedZone` to define that external-dns should only create records there.

I have thoroughly tested this configuration using educates 3 installation on AWS.

Fixes #545 