### PR TITLE
Getting the go version from go.work file

### DIFF
--- a/.github/workflows/build-and-publish-images.yaml
+++ b/.github/workflows/build-and-publish-images.yaml
@@ -17,9 +17,6 @@ on:
       - "[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+"
       - "[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+"
 
-env:
-  GO_VERSION: "1.23.7"
-
 jobs:
   publish-generic-images:
     name: Publish
@@ -534,7 +531,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.work
           cache-dependency-path: |
             client-programs/go.sum
 
@@ -580,7 +577,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.work
           cache-dependency-path: |
             client-programs/go.sum
 
@@ -626,7 +623,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.work
           cache-dependency-path: |
             client-programs/go.sum
 
@@ -677,7 +674,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{env.GO_VERSION}}
+          go-version-file: go.work
           cache-dependency-path: |
             client-programs/go.sum
 


### PR DESCRIPTION
Updated github action so that the action gets the golang version to use for building the client-programs (cli) from `go.work` file.
Verified in GH action run in fork https://github.com/jorgemoralespou/educates-training-platform/actions/runs/19427012756