### PR TITLE
Allow examiner scripts in packages and improve checks.

### DIFF
--- a/project-docs/index.rst
+++ b/project-docs/index.rst
@@ -81,6 +81,7 @@ Educates
   :maxdepth: 2
   :caption: Release Notes:
 
+  release-notes/version-3.6.0
   release-notes/version-3.5.1
   release-notes/version-3.5.0
   release-notes/version-3.4.0

--- a/project-docs/release-notes/version-3.6.0.md
+++ b/project-docs/release-notes/version-3.6.0.md
@@ -1,0 +1,18 @@
+Version 3.6.0
+=============
+
+New Features
+------------
+
+* Examiner test scripts can now be provided as part of an extension package.
+  These should be placed under the `examiner/tests` directory of the package.
+
+Features Changed
+----------------
+
+* When using the test examiner feature, test scripts can now be put in a sub
+  directory of the `/opt/workshop/examiner/tests` directory. The name of the
+  sub directory path should then prefix the test name when using the clickable
+  action for the test. Checks when running test examiner scripts have also
+  been beefed up to ensure that directory traversal cannot be used to execute
+  a program which resides outside of the tests directories.

--- a/project-docs/workshop-content/workshop-instructions.md
+++ b/project-docs/workshop-content/workshop-instructions.md
@@ -596,7 +596,7 @@ args:
 
 The ``title`` field will be displayed as the title of the clickable action and should describe the nature of the test. If required, you can provide a ``description`` field for a longer explaination of the test. This will be displayed in the body of the clickable action but will always be shown as preformatted text.
 
-There must exist an executable program (script or compiled application), in the ``workshop/examiner/tests`` directory with name matching the value of the ``name`` field.
+There must exist an executable program (script or compiled application), in the ``workshop/examiner/tests`` directory with name matching the value of the ``name`` field. In the case where it is located in a sub directory of ``workshop/examiner/tests``, the sub directory prefix must also be included in the ``name`` field.
 
 The list of program arguments listed against the ``args`` field will be passed to the test program.
 

--- a/workshop-images/base-environment/opt/gateway/src/backend/modules/examiner.ts
+++ b/workshop-images/base-environment/opt/gateway/src/backend/modules/examiner.ts
@@ -1,31 +1,132 @@
-import * as express from "express"
 import * as child_process from "child_process"
-import * as path from "path"
+import * as express from "express"
 import * as fs from "fs"
+import * as glob from "glob"
 import * as os from "os"
+import * as path from "path"
 
 import { config } from "./config"
 
-const test_program_directories = [
+const test_program_directory_patterns = [
     "/home/eduk8s/workshop/examiner/tests",
     "/opt/workshop/examiner/tests",
+    "/opt/packages/*/examiner/tests",
     "/opt/eduk8s/workshop/examiner/tests",
     "/opt/renderer/workshop/examiner/tests"
 ];
 
-function find_test_program(name) {
-    let i: any;
+/**
+ * Expands glob patterns in the test program directory list to get actual directories.
+ * This is called each time we need to search for a test program to handle directories
+ * that may be added after the application has started.
+ */
+function get_test_program_directories(): string[] {
+    const directories: string[] = []
 
-    for (i in test_program_directories) {
-        let pathname = path.join(test_program_directories[i], name);
-
-        try {
-            fs.accessSync(pathname, fs.constants.R_OK | fs.constants.X_OK);
-            return pathname;
-        } catch (err) {
-            // Ignore it.
+    for (const pattern of test_program_directory_patterns) {
+        // If pattern contains glob characters, expand it
+        if (pattern.includes("*") || pattern.includes("?") || pattern.includes("[")) {
+            directories.push(...glob.sync(pattern))
+        } else {
+            directories.push(pattern)
         }
     }
+
+    return directories
+}
+
+/**
+ * Validates that a test name contains only safe characters.
+ * Allows alphanumeric characters, hyphens, underscores, dots, forward slashes
+ * (for subdirectory grouping), colons, at signs, and plus signs.
+ */
+function validate_test_name(name: string): boolean {
+    if (!name || typeof name !== "string") {
+        return false
+    }
+
+    // Only allow alphanumeric, hyphens, underscores, dots, forward slashes, colons, at signs, and plus signs
+    const safePattern = /^[a-zA-Z0-9._/:@+-]+$/
+    return safePattern.test(name)
+}
+
+/**
+ * Validates that a canonical pathname is within the allowed directory.
+ * The pathname should already be resolved via fs.realpathSync() which follows
+ * symlinks and resolves all path components to produce an absolute canonical path.
+ */
+function validate_pathname(canonicalPath: string, canonicalDir: string): boolean {
+    if (!canonicalPath || typeof canonicalPath !== "string") {
+        return false
+    }
+
+    // Check if canonicalPath starts with the directory followed by path separator
+    return canonicalPath.startsWith(canonicalDir + path.sep)
+}
+
+/**
+ * Validates command arguments.
+ * Ensures args is an array of strings without null bytes.
+ * Empty strings are allowed as they are valid arguments.
+ */
+function validate_args(args: any): string[] | null {
+    if (!Array.isArray(args)) {
+        return null
+    }
+
+    const validatedArgs: string[] = []
+
+    for (const arg of args) {
+        if (typeof arg !== "string") {
+            return null
+        }
+
+        // Reject strings with null bytes (injection vector)
+        if (arg.includes("\0")) {
+            return null
+        }
+
+        validatedArgs.push(arg)
+    }
+
+    return validatedArgs
+}
+
+/**
+ * Locate a test program inside allowed directories.
+ * Performs name validation, canonical path resolution, and boundary validation.
+ */
+function find_test_program(name: string): string | null {
+    if (!validate_test_name(name)) {
+        console.error(`Invalid test name: ${name}`)
+        return null
+    }
+
+    for (const dir of get_test_program_directories()) {
+        const potentialPath = path.join(dir, name)
+
+        try {
+            // Check for file existence and executability
+            fs.accessSync(potentialPath, fs.constants.R_OK | fs.constants.X_OK)
+
+            // Resolve the file path to its canonical form (follows symlinks, resolves ..)
+            const canonicalPath = fs.realpathSync(potentialPath)
+
+            // Validate the canonical path to ensure it is within the allowed directory.
+            // Use the original dir value (not canonicalised) to ensure the allowed
+            // directory path itself does not contain symlinks.
+            if (!validate_pathname(canonicalPath, dir)) {
+                console.error(`Security alert: Path ${potentialPath} resolved to unauthorized location ${canonicalPath}`)
+                continue
+            }
+
+            return canonicalPath
+        } catch (err) {
+            // File doesn't exist or isn't accessible, continue searching
+        }
+    }
+
+    return null
 }
 
 export function setup_examiner(app: express.Application, token: string = null) {
@@ -35,13 +136,24 @@ export function setup_examiner(app: express.Application, token: string = null) {
     app.use("/examiner/test/", express.json());
 
     async function examiner_test(req, res, next) {
-        let test = req.params.test
+        // Use params[0] for wildcard route that captures paths with slashes
+        let test = req.params[0]
 
-        let options = req.body
+        let options = req.body || {}
 
         let timeout = options.timeout || 15
-        let args = options.args || []
         let form = options.form || {}
+
+        // Validate and sanitize args
+        let args = validate_args(options.args || [])
+
+        if (args === null) {
+            console.error(`${test}: Invalid arguments provided`)
+            return res.status(400).json({
+                success: false,
+                message: "Invalid arguments: must be an array of strings"
+            })
+        }
 
         if (!test)
             return next()
@@ -118,7 +230,7 @@ export function setup_examiner(app: express.Application, token: string = null) {
                 lines.forEach((line) => {
                     const logData = `${test}: ${line}`;
                     console.log(logData);
-                    logStream.write(logData+'\n'); // Append stdout to the log file.
+                    logStream.write(logData + '\n'); // Append stdout to the log file.
                 });
             });
 
@@ -127,7 +239,7 @@ export function setup_examiner(app: express.Application, token: string = null) {
                 lines.forEach((line) => {
                     const logData = `${test}: ${line}`;
                     console.log(logData);
-                    logStream.write(logData+'\n'); // Append stderr to the log file.
+                    logStream.write(logData + '\n'); // Append stderr to the log file.
                 });
             });
 
@@ -151,7 +263,7 @@ export function setup_examiner(app: express.Application, token: string = null) {
     }
 
     if (token) {
-        app.post("/examiner/test/:test", async function (req, res, next) {
+        app.post("/examiner/test/*", async function (req, res, next) {
             let request_token = req.query.token
 
             if (!request_token || request_token != token)
@@ -161,6 +273,6 @@ export function setup_examiner(app: express.Application, token: string = null) {
         })
     }
     else {
-        app.post("/examiner/test/:test", examiner_test)
+        app.post("/examiner/test/*", examiner_test)
     }
 }


### PR DESCRIPTION
My variant of improvements to examiner test script handling.

* Don't allow traversal outside of examiner tests directories.
* Allow programs in sub directories of examiner tests directories.
* Allow examiner tests to be bundled with extension packages.

closes #837 
closes #838
closes #847