### PR TITLE
Add terminal actions sample workshop for testing.

### DIFF
--- a/developer-docs/build-instructions.md
+++ b/developer-docs/build-instructions.md
@@ -225,3 +225,10 @@ If you're working on updates or additions to the project documentation served at
 make build-project-docs
 make open-project-docs
 ```
+
+Sample workshops for testing
+----------------------------
+
+A set of sample workshops are provided for testing and demonstrating different features of the Educates platform. These are not intended for end user consumption but serve as minimal pre-canned workshops for verifying platform functionality.
+
+For details on the available sample workshops and instructions on how to deploy them, see the [workshop samples README](../workshop-samples/README.md).

--- a/workshop-samples/README.md
+++ b/workshop-samples/README.md
@@ -1,0 +1,41 @@
+Workshop Samples
+================
+
+This directory contains various workshop samples. These are not intended for
+end user consumption and are intended to provide some minimal pre-canned
+workshops which can be used to test and demonstrate different features of
+the Educates platform.
+
+Deploying Workshops
+-------------------
+
+To deploy a workshop from one of the sub directories, first ensure you have
+an Educates cluster available and the `educates` CLI installed. Then from the
+root of the workshop sub directory, run the following commands.
+
+Publish the workshop to the Educates cluster:
+
+```
+educates publish-workshop
+```
+
+Deploy the workshop so that it is available to users:
+
+```
+educates deploy-workshop
+```
+
+Once deployed, you can browse available workshops and access them by running:
+
+```
+educates browse-workshops
+```
+
+This will open a browser window where you can select and launch the workshop.
+
+Available Workshops
+-------------------
+
+* [lab-terminal-actions](lab-terminal-actions/) - Test workshop for verifying
+  all terminal clickable action types including both the current preferred
+  action formats and deprecated legacy formats.

--- a/workshop-samples/lab-terminal-actions/README.md
+++ b/workshop-samples/lab-terminal-actions/README.md
@@ -1,0 +1,4 @@
+Terminal Clickable Actions Test
+===============================
+
+Test workshop for verifying all terminal clickable action types provided by Educates, including both the current preferred action formats and deprecated legacy formats.

--- a/workshop-samples/lab-terminal-actions/resources/workshop.yaml
+++ b/workshop-samples/lab-terminal-actions/resources/workshop.yaml
@@ -1,0 +1,30 @@
+apiVersion: training.educates.dev/v1beta1
+kind: Workshop
+metadata:
+  name: lab-terminal-actions
+spec:
+  title: Terminal Clickable Actions Test
+  description: Test workshop for verifying all terminal clickable action types including both current and deprecated formats.
+  duration: 15m
+  difficulty: beginner
+  publish:
+    image: "$(image_repository)/lab-terminal-actions-files:$(workshop_version)"
+  workshop:
+    files:
+    - image:
+        url: "$(image_repository)/lab-terminal-actions-files:$(workshop_version)"
+      includePaths:
+      - /workshop/**
+      - /README.md
+  session:
+    namespaces:
+      security:
+        token:
+          enabled: false
+    applications:
+      terminal:
+        enabled: true
+        layout: split/2
+    dashboards:
+    - name: Terminal#4
+      url: terminal:4

--- a/workshop-samples/lab-terminal-actions/workshop/content/00-workshop-overview.md
+++ b/workshop-samples/lab-terminal-actions/workshop/content/00-workshop-overview.md
@@ -1,0 +1,30 @@
+---
+title: Workshop Overview
+---
+
+This workshop is a test suite for verifying all terminal-related clickable
+actions supported by Educates. It is not intended as an end-user workshop but
+rather as a functional test to confirm that each action type behaves correctly.
+
+The workshop is configured with a `split/2` terminal layout providing three
+terminal sessions in the Terminal tab, plus an additional dashboard tab named
+"Terminal#4" providing access to a fourth terminal session.
+
+The following categories of clickable actions are tested across the workshop
+pages:
+
+**Preferred clickable actions (current format):**
+
+- `terminal:execute` — Execute a command in a specific terminal session
+- `terminal:execute-all` — Execute a command in all terminal sessions
+- `terminal:input` — Send text to a terminal without automatic execution
+- `terminal:interrupt` — Send Ctrl-C to a specific terminal session
+- `terminal:interrupt-all` — Send Ctrl-C to all terminal sessions
+- `terminal:clear` — Clear a specific terminal session
+- `terminal:clear-all` — Clear all terminal sessions
+
+**Deprecated clickable actions (legacy format):**
+
+- `execute` — Legacy equivalent of `terminal:execute`
+- `execute-1`, `execute-2`, `execute-3` — Legacy terminal-specific execution
+- `execute-all` — Legacy equivalent of `terminal:execute-all`

--- a/workshop-samples/lab-terminal-actions/workshop/content/01-terminal-execute.md
+++ b/workshop-samples/lab-terminal-actions/workshop/content/01-terminal-execute.md
@@ -1,0 +1,139 @@
+---
+title: "Terminal Execute"
+---
+
+The `terminal:execute` action executes a command in a terminal session. By
+default the command is directed to terminal session 1. The content of the code
+block is YAML with the command specified via the `command` property.
+
+## Basic Command Execution
+
+This test executes a simple echo command in the default terminal (session 1).
+
+The markdown for this action is:
+
+~~~
+```terminal:execute
+command: |-
+  echo "Hello from terminal:execute"
+```
+~~~
+
+Click the action below to test it:
+
+```terminal:execute
+command: |-
+  echo "Hello from terminal:execute"
+```
+
+## Command with Clear
+
+The `clear` property can be set to `true` to clear the full terminal buffer
+before executing the command. This clears the entire scrollback buffer, not just
+the visible portion.
+
+The markdown for this action is:
+
+~~~
+```terminal:execute
+command: echo "Terminal was cleared before this command"
+clear: true
+```
+~~~
+
+Click the action below to test it:
+
+```terminal:execute
+command: echo "Terminal was cleared before this command"
+clear: true
+```
+
+## Multi-line Command as Separate Commands
+
+When a multi-line string is provided via the YAML `command` property, each line
+is sent to the shell individually. This means the first line is executed and a
+new shell prompt is displayed, then the next line is executed, and so on. They
+are not treated as a single compound command.
+
+The markdown for this action is:
+
+~~~
+```terminal:execute
+command: |-
+  echo "First command"
+  echo "Second command"
+  echo "Third command"
+```
+~~~
+
+Click the action below to test it. Notice that each echo command results in a
+separate shell prompt being shown between commands:
+
+```terminal:execute
+command: |-
+  echo "First command"
+  echo "Second command"
+  echo "Third command"
+```
+
+## Multi-line Command with Continuation
+
+To have multiple lines treated as sequential commands against the same shell
+prompt, use a semicolon and backslash continuation character at the end of all
+but the last line. This causes the shell to treat them as a single compound
+command.
+
+The markdown for this action is:
+
+~~~
+```terminal:execute
+command: |-
+  echo "First command"; \
+  echo "Second command"; \
+  echo "Third command"
+```
+~~~
+
+Click the action below to test it. Notice that all three echo commands run
+under a single shell prompt:
+
+```terminal:execute
+command: |-
+  echo "First command"; \
+  echo "Second command"; \
+  echo "Third command"
+```
+
+## Multi-line Content using Heredoc
+
+A practical use of multi-line commands is creating file content using a shell
+heredoc. This is a single command that naturally spans multiple lines, where the
+heredoc body is sent as standard input to the command.
+
+The markdown for this action is:
+
+~~~
+```terminal:execute
+command: |-
+  cat << 'EOF' > /tmp/sample.txt
+  This is line 1 of the file.
+  This is line 2 of the file.
+  This is line 3 of the file.
+  EOF
+```
+~~~
+
+Click the action below to create the file, then verify its contents:
+
+```terminal:execute
+command: |-
+  cat << 'EOF' > /tmp/sample.txt
+  This is line 1 of the file.
+  This is line 2 of the file.
+  This is line 3 of the file.
+  EOF
+```
+
+```terminal:execute
+command: cat /tmp/sample.txt
+```

--- a/workshop-samples/lab-terminal-actions/workshop/content/02-terminal-execute-sessions.md
+++ b/workshop-samples/lab-terminal-actions/workshop/content/02-terminal-execute-sessions.md
@@ -1,0 +1,91 @@
+---
+title: "Terminal Execute with Session Targeting"
+---
+
+The `terminal:execute` action accepts a `session` property to direct the command
+to a specific terminal session. The workshop is configured with a `split/2`
+layout providing three terminal sessions in the Terminal tab, plus a fourth
+terminal accessible via the "Terminal#4" dashboard tab.
+
+## Execute in Terminal 1
+
+The markdown for this action is:
+
+~~~
+```terminal:execute
+command: echo "Executed in terminal 1"
+session: 1
+```
+~~~
+
+Click the action below to test it:
+
+```terminal:execute
+command: echo "Executed in terminal 1"
+session: 1
+```
+
+## Execute in Terminal 2
+
+The markdown for this action is:
+
+~~~
+```terminal:execute
+command: echo "Executed in terminal 2"
+session: 2
+```
+~~~
+
+Click the action below to test it:
+
+```terminal:execute
+command: echo "Executed in terminal 2"
+session: 2
+```
+
+## Execute in Terminal 3
+
+Terminal 3 is the third terminal in the `split/2` layout.
+
+The markdown for this action is:
+
+~~~
+```terminal:execute
+command: echo "Executed in terminal 3"
+session: 3
+```
+~~~
+
+Click the action below to test it:
+
+```terminal:execute
+command: echo "Executed in terminal 3"
+session: 3
+```
+
+## Execute in Terminal 4
+
+Terminal 4 is not part of the `split/2` layout in the Terminal tab. It is
+exposed as a separate dashboard tab named "Terminal#4" configured with `url`
+set to `terminal:4`. Because the portion after the `terminal:` prefix in the
+URL is `4`, the session name used to target it is also `4`.
+
+The markdown for this action is:
+
+~~~
+```terminal:execute
+command: echo "Executed in terminal 4"
+session: 4
+```
+~~~
+
+Click the action below to test it. You should see the output appear in the
+"Terminal#4" dashboard tab:
+
+```terminal:execute
+command: echo "Executed in terminal 4"
+session: 4
+```
+
+After clicking any of the above, the targeted terminal session will remain
+selected so that any subsequent manual input is directed to that terminal.

--- a/workshop-samples/lab-terminal-actions/workshop/content/03-terminal-execute-all.md
+++ b/workshop-samples/lab-terminal-actions/workshop/content/03-terminal-execute-all.md
@@ -1,0 +1,44 @@
+---
+title: "Terminal Execute All"
+---
+
+The `terminal:execute-all` action executes a command simultaneously in all
+terminal sessions on the Terminal tab of the dashboard. After execution, the
+first terminal session is left selected.
+
+## Basic Execute All
+
+The markdown for this action is:
+
+~~~
+```terminal:execute-all
+command: echo "Executed in all terminals"
+```
+~~~
+
+Click the action below to test it:
+
+```terminal:execute-all
+command: echo "Executed in all terminals"
+```
+
+## Execute All with Clear
+
+The `clear` property works with `terminal:execute-all` as well, clearing the
+full buffer of every terminal session before executing the command.
+
+The markdown for this action is:
+
+~~~
+```terminal:execute-all
+command: echo "All terminals cleared then this ran"
+clear: true
+```
+~~~
+
+Click the action below to test it:
+
+```terminal:execute-all
+command: echo "All terminals cleared then this ran"
+clear: true
+```

--- a/workshop-samples/lab-terminal-actions/workshop/content/04-terminal-input.md
+++ b/workshop-samples/lab-terminal-actions/workshop/content/04-terminal-input.md
@@ -1,0 +1,140 @@
+---
+title: "Terminal Input"
+---
+
+The `terminal:input` action sends text to a terminal session using bracketed
+paste mode. This is distinct from `terminal:execute` in that the text is pasted
+into the terminal rather than being submitted as a command. Because bracketed
+paste mode is used, even if a trailing newline is included in the text, the
+terminal will not automatically act on it. The user would still need to press
+Enter for the shell to process the pasted text.
+
+The primary use case for `terminal:input` is when a running program is prompting
+for interactive input such as a password, confirmation, or other data entry
+rather than a shell command.
+
+By default a newline is appended to the text (controlled by the `endl`
+property). However, because of bracketed paste mode, this newline is included in
+the pasted content but does not trigger command execution at a shell prompt. When
+sending input to a program that is actively reading from stdin (such as `read`),
+the newline will be consumed as the end-of-input marker by that program.
+
+## Basic Input to a Waiting Prompt
+
+To properly test `terminal:input`, we first need a program that is waiting for
+input. The `read` shell builtin is ideal for this as it displays a prompt and
+waits for the user to provide a value.
+
+First, start a `read` command that will wait for input:
+
+```terminal:execute
+command: |-
+  read -p "Enter your name: " NAME && echo "Hello, $NAME!"
+```
+
+Now use `terminal:input` to send text to the waiting prompt. Because `read` is
+actively waiting for input, it will consume the text and the trailing newline,
+completing the input.
+
+The markdown for this action is:
+
+~~~
+```terminal:input
+text: World
+```
+~~~
+
+Click the action below to test it:
+
+```terminal:input
+text: World
+```
+
+You should see "Hello, World!" printed after the input is received.
+
+## Input Without Newline
+
+Setting `endl: false` sends the text without appending a newline. This means the
+text appears at the prompt but the program continues to wait for more input
+until Enter is pressed manually.
+
+First, start another `read` command waiting for input:
+
+```terminal:execute
+command: |-
+  read -p "Enter a color: " COLOR && echo "You chose: $COLOR"
+```
+
+The markdown for this action is:
+
+~~~
+```terminal:input
+text: blue
+endl: false
+```
+~~~
+
+Click the action below to test it:
+
+```terminal:input
+text: blue
+endl: false
+```
+
+After clicking the above, you should see "blue" appear at the prompt but the
+`read` command will still be waiting. Press Enter manually to complete the input
+and see the result.
+
+## Input to Specific Session
+
+The `session` property can be used to direct input to a specific terminal
+session.
+
+First, start a `read` command in terminal 2:
+
+```terminal:execute
+command: |-
+  read -p "Enter a value: " VAL && echo "Got: $VAL"
+session: 2
+```
+
+The markdown for this action is:
+
+~~~
+```terminal:input
+text: hello from session 2
+session: 2
+```
+~~~
+
+Click the action below to send input to terminal 2:
+
+```terminal:input
+text: hello from session 2
+session: 2
+```
+
+## Input at a Shell Prompt
+
+When `terminal:input` is used against a shell prompt rather than a program
+waiting for input, the text is pasted but not executed due to bracketed paste
+mode. Even though a trailing newline is included by default, the shell will not
+process the pasted text until Enter is pressed manually.
+
+The markdown for this action is:
+
+~~~
+```terminal:input
+text: echo "This was pasted, not executed"
+```
+~~~
+
+Click the action below to test it:
+
+```terminal:input
+text: echo "This was pasted, not executed"
+```
+
+After clicking the above, you should see the text appear at the shell prompt
+but it will not be executed. Press Enter manually to have the shell process the
+command, or press Ctrl-C to discard it.

--- a/workshop-samples/lab-terminal-actions/workshop/content/05-terminal-interrupt.md
+++ b/workshop-samples/lab-terminal-actions/workshop/content/05-terminal-interrupt.md
@@ -1,0 +1,66 @@
+---
+title: "Terminal Interrupt"
+---
+
+The `terminal:interrupt` action sends a Ctrl-C signal to a terminal session to
+interrupt a running command. The `terminal:interrupt-all` variant sends the
+interrupt to all terminal sessions simultaneously.
+
+## Setup: Start a Long-Running Command
+
+First, start a long-running command in terminal 1 that we can then interrupt.
+
+```terminal:execute
+command: while true; do echo "Running... $(date)"; sleep 1; done
+session: 1
+```
+
+## Interrupt Terminal 1
+
+The `terminal:interrupt` action targets terminal session 1 by default. You can
+optionally specify the `session` property.
+
+The markdown for this action is:
+
+~~~
+```terminal:interrupt
+session: 1
+```
+~~~
+
+Click the action below to interrupt the running command:
+
+```terminal:interrupt
+session: 1
+```
+
+## Setup: Start Commands in Multiple Terminals
+
+Start long-running commands in terminals 1 and 2 to test `terminal:interrupt-all`.
+
+```terminal:execute
+command: while true; do echo "Terminal 1 running... $(date)"; sleep 1; done
+session: 1
+```
+
+```terminal:execute
+command: while true; do echo "Terminal 2 running... $(date)"; sleep 1; done
+session: 2
+```
+
+## Interrupt All Terminals
+
+The `terminal:interrupt-all` action sends Ctrl-C to all terminal sessions on the
+Terminal tab.
+
+The markdown for this action is:
+
+~~~
+```terminal:interrupt-all
+```
+~~~
+
+Click the action below to interrupt all running commands:
+
+```terminal:interrupt-all
+```

--- a/workshop-samples/lab-terminal-actions/workshop/content/06-terminal-clear.md
+++ b/workshop-samples/lab-terminal-actions/workshop/content/06-terminal-clear.md
@@ -1,0 +1,56 @@
+---
+title: "Terminal Clear"
+---
+
+The `terminal:clear` action clears the full terminal buffer (including
+scrollback) for a specific terminal session. The `terminal:clear-all` variant
+clears all terminal sessions. These actions should have no effect when an
+application running in the terminal is using visual mode.
+
+Note: if you only want to clear the visible portion of the terminal (equivalent
+to running the `clear` command), use `terminal:execute` with `command: clear`
+instead.
+
+## Setup: Generate Output
+
+First, generate some output in terminals 1 and 2 so there is content to clear.
+
+```terminal:execute
+command: for i in $(seq 1 20); do echo "Terminal 1 - Line $i"; done
+session: 1
+```
+
+```terminal:execute
+command: for i in $(seq 1 20); do echo "Terminal 2 - Line $i"; done
+session: 2
+```
+
+## Clear Terminal 1
+
+The markdown for this action is:
+
+~~~
+```terminal:clear
+session: 1
+```
+~~~
+
+Click the action below to clear terminal 1:
+
+```terminal:clear
+session: 1
+```
+
+## Clear All Terminals
+
+The markdown for this action is:
+
+~~~
+```terminal:clear-all
+```
+~~~
+
+Click the action below to clear all terminals:
+
+```terminal:clear-all
+```

--- a/workshop-samples/lab-terminal-actions/workshop/content/07-deprecated-execute.md
+++ b/workshop-samples/lab-terminal-actions/workshop/content/07-deprecated-execute.md
@@ -1,0 +1,53 @@
+---
+title: "Deprecated: Execute Action"
+---
+
+The `execute` code block annotation is the original legacy format for executing
+commands in a terminal. It has been superseded by `terminal:execute` which uses
+YAML-based configuration. The `execute` format is still supported for backward
+compatibility but should not be used in new workshops.
+
+With the deprecated format, the body of the code block is the command itself
+(not YAML). By default it targets terminal session 1.
+
+## Basic Execute
+
+The markdown for this action is:
+
+~~~
+```execute
+echo "Hello from deprecated execute"
+```
+~~~
+
+Click the action below to test it:
+
+```execute
+echo "Hello from deprecated execute"
+```
+
+## Deprecated Ctrl-C via Execute
+
+In the original format, sending Ctrl-C to interrupt a running command was done
+by using the special string `<ctrl+c>` as the body of an `execute` block. This
+is deprecated in favor of the `terminal:interrupt` action.
+
+First, start a long-running command:
+
+```execute
+while true; do echo "Running... $(date)"; sleep 1; done
+```
+
+The markdown for the deprecated interrupt is:
+
+~~~
+```execute
+<ctrl+c>
+```
+~~~
+
+Click the action below to interrupt it using the deprecated method:
+
+```execute
+<ctrl+c>
+```

--- a/workshop-samples/lab-terminal-actions/workshop/content/08-deprecated-execute-numbered.md
+++ b/workshop-samples/lab-terminal-actions/workshop/content/08-deprecated-execute-numbered.md
@@ -1,0 +1,60 @@
+---
+title: "Deprecated: Execute with Terminal Numbers"
+---
+
+When the workshop dashboard is configured to display multiple terminals, the
+original legacy format allowed targeting a specific terminal by appending a
+number suffix to the `execute` annotation: `execute-1`, `execute-2`, and
+`execute-3`. These have been superseded by `terminal:execute` with the `session`
+property.
+
+## Execute-1 (Terminal 1)
+
+The markdown for this action is:
+
+~~~
+```execute-1
+echo "Hello from deprecated execute-1"
+```
+~~~
+
+Click the action below to test it:
+
+```execute-1
+echo "Hello from deprecated execute-1"
+```
+
+## Execute-2 (Terminal 2)
+
+The markdown for this action is:
+
+~~~
+```execute-2
+echo "Hello from deprecated execute-2"
+```
+~~~
+
+Click the action below to test it:
+
+```execute-2
+echo "Hello from deprecated execute-2"
+```
+
+## Execute-3 (Terminal 3)
+
+The markdown for this action is:
+
+~~~
+```execute-3
+echo "Hello from deprecated execute-3"
+```
+~~~
+
+Click the action below to test it:
+
+```execute-3
+echo "Hello from deprecated execute-3"
+```
+
+The preferred replacement for all of the above is `terminal:execute` with the
+`session` property set to the desired terminal number.

--- a/workshop-samples/lab-terminal-actions/workshop/content/09-deprecated-execute-all.md
+++ b/workshop-samples/lab-terminal-actions/workshop/content/09-deprecated-execute-all.md
@@ -1,0 +1,48 @@
+---
+title: "Deprecated: Execute All"
+---
+
+The `execute-all` code block annotation is the original legacy format for
+executing a command in all terminal sessions. It has been superseded by
+`terminal:execute-all`. Like the other deprecated formats, the body of the code
+block is the command itself rather than YAML.
+
+## Basic Execute All
+
+The markdown for this action is:
+
+~~~
+```execute-all
+echo "Hello from deprecated execute-all"
+```
+~~~
+
+Click the action below to test it:
+
+```execute-all
+echo "Hello from deprecated execute-all"
+```
+
+After execution, the first terminal session is left selected.
+
+## Clear All via Deprecated Execute All
+
+A common use of the original `execute-all` was to clear all terminals.
+
+The markdown for this action is:
+
+~~~
+```execute-all
+clear
+```
+~~~
+
+Click the action below to test it:
+
+```execute-all
+clear
+```
+
+Note that using `execute-all` with the `clear` command only clears the visible
+portion of each terminal. The preferred `terminal:execute-all` with
+`clear: true` clears the full buffer including scrollback.

--- a/workshop-samples/lab-terminal-actions/workshop/content/99-workshop-summary.md
+++ b/workshop-samples/lab-terminal-actions/workshop/content/99-workshop-summary.md
@@ -1,0 +1,26 @@
+---
+title: Workshop Summary
+---
+
+This workshop tested all terminal-related clickable actions supported by
+Educates.
+
+**Preferred actions tested:**
+
+- `terminal:execute` — Basic execution, with `clear`, multi-line, and `session` targeting
+- `terminal:execute-all` — Execution across all terminals, with `clear`
+- `terminal:input` — Text input with and without newline, with session targeting
+- `terminal:interrupt` — Interrupt specific terminal session
+- `terminal:interrupt-all` — Interrupt all terminal sessions
+- `terminal:clear` — Clear specific terminal buffer
+- `terminal:clear-all` — Clear all terminal buffers
+
+**Deprecated actions tested:**
+
+- `execute` — Legacy command execution and `<ctrl+c>` interrupt
+- `execute-1`, `execute-2`, `execute-3` — Legacy terminal-specific execution
+- `execute-all` — Legacy execution across all terminals
+
+All deprecated actions remain functional for backward compatibility but should
+not be used in new workshop content. Use the `terminal:*` namespaced actions
+instead.


### PR DESCRIPTION
This is start of a workshop-samples directory for various workshops which help to test mechanics of clickable actions or workshop definitions. Adding this here in the main code repo as we keep loosing where separate repos are they get deleted. So aim is to keep key sample workshops for testing in this repo.