### PR TITLE
Fix clearing of terminals when using execute-all clickable action.

### DIFF
--- a/project-docs/release-notes/version-3.6.0.md
+++ b/project-docs/release-notes/version-3.6.0.md
@@ -8,6 +8,9 @@ Bugs Fixed
   This has only been fixed for Hugo renderer and not the deprecated classic
   renderer.
 
+* When using the `terminal:execute-all` clickable action, if `clear` was set
+  to `true`, the terminals were not being cleared.
+
 New Features
 ------------
 

--- a/workshop-images/base-environment/opt/gateway/src/frontend/scripts/educates.ts
+++ b/workshop-images/base-environment/opt/gateway/src/frontend/scripts/educates.ts
@@ -1228,9 +1228,9 @@ class Terminals {
         if (command == "<ctrl-c>" || command == "<ctrl+c>")
             return await this.interrupt_all_terminals()
 
-        await this.execute_in_terminal(command, "1")
-        await this.execute_in_terminal(command, "2")
-        await this.execute_in_terminal(command, "3")
+        await this.execute_in_terminal(command, "1", clear)
+        await this.execute_in_terminal(command, "2", clear)
+        await this.execute_in_terminal(command, "3", clear)
 
         this.select_terminal("1")
     }


### PR DESCRIPTION
fixes #886
