### PR TITLE
Fix/carvel installer

### DIFF
--- a/carvel-packages/installer/bundle/config/ytt/_ytt_lib/infrastructure/custom/90-overlays.yaml
+++ b/carvel-packages/installer/bundle/config/ytt/_ytt_lib/infrastructure/custom/90-overlays.yaml
@@ -24,5 +24,5 @@ clusterPackages:
 
 #@overlay/merge
   educates:
-    #@ if/end hasattr(data.values, "clusterPackages") and hasattr(data.values.clusterPackages, "educates") and hasattr(data.values.clusterPackages["educates"], "settings") and data.values.clusterPackages["educates"].settings:
+    #@ if/end hasattr(data.values, "clusterPackages") and hasattr(data.values.clusterPackages, "educates") and hasattr(data.values.clusterPackages["educates"], "settings"):
     settings: #@ data.values.clusterPackages["educates"].settings

--- a/carvel-packages/installer/bundle/config/ytt/_ytt_lib/infrastructure/generic/10-default-settings-for-provider.yaml
+++ b/carvel-packages/installer/bundle/config/ytt/_ytt_lib/infrastructure/generic/10-default-settings-for-provider.yaml
@@ -1,6 +1,6 @@
 #@ load("@ytt:data", "data")
 #@ load("@ytt:overlay", "overlay")
-#@ load("functions.star", "isClusterPackageEnableByDefault")
+#@ load("functions.star", "xgetattr", "isClusterPackageEnableByDefault")
 
 #! This file contains default values for the custom infrastructure provider.
 #! These are the values that will be set if not overridden by the user.
@@ -28,4 +28,4 @@ clusterPackages:
     settings: {}
   educates:
     enabled: #@ isClusterPackageEnableByDefault("educates")
-    settings: {}
+    settings: #@ xgetattr(data.values, "clusterPackages.educates.settings")

--- a/carvel-packages/installer/bundle/config/ytt/_ytt_lib/infrastructure/generic/50-packages-enablement.yaml
+++ b/carvel-packages/installer/bundle/config/ytt/_ytt_lib/infrastructure/generic/50-packages-enablement.yaml
@@ -5,9 +5,7 @@
 
 #@overlay/match-child-defaults missing_ok=True
 clusterPackages:
-  contour:
-    #@ if/end hasattr(data.values, "clusterPackages") and hasattr(data.values.clusterPackages, "contour") and hasattr(data.values.clusterPackages.contour, "enabled"):
-    enabled: #@ data.values.clusterPackages.contour.enabled
+  #! contour enablement is immutable for generic provider (cannot be enabled via values)
   cert-manager:
     #@ if/end hasattr(data.values, "clusterPackages") and hasattr(data.values.clusterPackages, "cert-manager") and hasattr(data.values.clusterPackages["cert-manager"], "enabled"):
     enabled: #@ data.values.clusterPackages["cert-manager"].enabled
@@ -23,6 +21,4 @@ clusterPackages:
   kapp-controller:
     #@ if/end hasattr(data.values, "clusterPackages") and hasattr(data.values.clusterPackages, "kapp-controller") and hasattr(data.values.clusterPackages["kapp-controller"], "enabled"):
     enabled: #@ data.values.clusterPackages["kapp-controller"].enabled
-  educates:
-    #@ if/end hasattr(data.values, "clusterPackages") and hasattr(data.values.clusterPackages, "educates") and hasattr(data.values.clusterPackages.educates, "enabled"):
-    enabled: #@ data.values.clusterPackages.educates.enabled
+  #! educates enablement is immutable for generic provider (always enabled)

--- a/carvel-packages/installer/bundle/config/ytt/_ytt_lib/infrastructure/generic/50-packages-enablement.yaml
+++ b/carvel-packages/installer/bundle/config/ytt/_ytt_lib/infrastructure/generic/50-packages-enablement.yaml
@@ -5,6 +5,24 @@
 
 #@overlay/match-child-defaults missing_ok=True
 clusterPackages:
+  contour:
+    #@ if/end hasattr(data.values, "clusterPackages") and hasattr(data.values.clusterPackages, "contour") and hasattr(data.values.clusterPackages.contour, "enabled"):
+    enabled: #@ data.values.clusterPackages.contour.enabled
+  cert-manager:
+    #@ if/end hasattr(data.values, "clusterPackages") and hasattr(data.values.clusterPackages, "cert-manager") and hasattr(data.values.clusterPackages["cert-manager"], "enabled"):
+    enabled: #@ data.values.clusterPackages["cert-manager"].enabled
+  external-dns:
+    #@ if/end hasattr(data.values, "clusterPackages") and hasattr(data.values.clusterPackages, "external-dns") and hasattr(data.values.clusterPackages["external-dns"], "enabled"):
+    enabled: #@ data.values.clusterPackages["external-dns"].enabled
+  certs:
+    #@ if/end hasattr(data.values, "clusterPackages") and hasattr(data.values.clusterPackages, "certs") and hasattr(data.values.clusterPackages.certs, "enabled"):
+    enabled: #@ data.values.clusterPackages.certs.enabled
   kyverno:
     #@ if/end hasattr(data.values, "clusterPackages") and hasattr(data.values.clusterPackages, "kyverno") and hasattr(data.values.clusterPackages.kyverno, "enabled"):
     enabled: #@ data.values.clusterPackages.kyverno.enabled
+  kapp-controller:
+    #@ if/end hasattr(data.values, "clusterPackages") and hasattr(data.values.clusterPackages, "kapp-controller") and hasattr(data.values.clusterPackages["kapp-controller"], "enabled"):
+    enabled: #@ data.values.clusterPackages["kapp-controller"].enabled
+  educates:
+    #@ if/end hasattr(data.values, "clusterPackages") and hasattr(data.values.clusterPackages, "educates") and hasattr(data.values.clusterPackages.educates, "enabled"):
+    enabled: #@ data.values.clusterPackages.educates.enabled

--- a/carvel-packages/installer/bundle/config/ytt/_ytt_lib/infrastructure/generic/educates.lib.yaml
+++ b/carvel-packages/installer/bundle/config/ytt/_ytt_lib/infrastructure/generic/educates.lib.yaml
@@ -74,7 +74,7 @@ trainingPortal:
       username: #@ data.values.trainingPortal.credentials.admin.username
       #@ if/end hasattr(data.values.trainingPortal.credentials.admin, "password") and data.values.trainingPortal.credentials.admin.password != None:
       password: #@ data.values.trainingPortal.credentials.admin.password
-    #@ if/end hasattr(data.values.trainingPortal.credentials, "robot") and data.values.trainingPortal.credentials.admin != None:
+    #@ if/end hasattr(data.values.trainingPortal.credentials, "robot") and data.values.trainingPortal.credentials.robot != None:
     robot:
       #@ if/end hasattr(data.values.trainingPortal.credentials.robot, "username") and data.values.trainingPortal.credentials.robot.username != None:
       username: #@ data.values.trainingPortal.credentials.robot.username

--- a/carvel-packages/installer/bundle/config/ytt/_ytt_lib/infrastructure/generic/functions.star
+++ b/carvel-packages/installer/bundle/config/ytt/_ytt_lib/infrastructure/generic/functions.star
@@ -16,3 +16,20 @@ end
 def isClusterPackageExplicitDisabled(package):
   return not isClusterPackageEnabled(package)
 end
+
+def xgetattr(object, path, default=None):
+  def _lookup(object, key, default=None):
+    keys = key.split(".")
+    value = default
+    for key in keys:
+      value = getattr(object, key, None)
+      if value == None:
+        return default
+      end
+      object = value
+    end
+    return value
+  end
+
+  return _lookup(object, path, default)
+end

--- a/carvel-packages/installer/bundle/config/ytt/_ytt_lib/infrastructure/minikube/10-default-settings-for-provider.yaml
+++ b/carvel-packages/installer/bundle/config/ytt/_ytt_lib/infrastructure/minikube/10-default-settings-for-provider.yaml
@@ -1,6 +1,6 @@
 #@ load("@ytt:data", "data")
 #@ load("@ytt:overlay", "overlay")
-#@ load("functions.star", "isClusterPackageEnableByDefault")
+#@ load("functions.star", "xgetattr", "isClusterPackageEnableByDefault")
 
 #! This file contains default values for the custom infrastructure provider.
 #! These are the values that will be set if not overridden by the user.
@@ -37,4 +37,4 @@ clusterPackages:
     settings: {}
   educates:
     enabled: #@ isClusterPackageEnableByDefault("educates")
-    settings: {}
+    settings: #@ xgetattr(data.values, "clusterPackages.educates.settings")

--- a/carvel-packages/installer/bundle/config/ytt/_ytt_lib/infrastructure/minikube/educates.lib.yaml
+++ b/carvel-packages/installer/bundle/config/ytt/_ytt_lib/infrastructure/minikube/educates.lib.yaml
@@ -74,7 +74,7 @@ trainingPortal:
       username: #@ data.values.trainingPortal.credentials.admin.username
       #@ if/end hasattr(data.values.trainingPortal.credentials.admin, "password") and data.values.trainingPortal.credentials.admin.password != None:
       password: #@ data.values.trainingPortal.credentials.admin.password
-    #@ if/end hasattr(data.values.trainingPortal.credentials, "robot") and data.values.trainingPortal.credentials.admin != None:
+    #@ if/end hasattr(data.values.trainingPortal.credentials, "robot") and data.values.trainingPortal.credentials.robot != None:
     robot:
       #@ if/end hasattr(data.values.trainingPortal.credentials.robot, "username") and data.values.trainingPortal.credentials.robot.username != None:
       username: #@ data.values.trainingPortal.credentials.robot.username

--- a/carvel-packages/installer/bundle/config/ytt/_ytt_lib/infrastructure/minikube/functions.star
+++ b/carvel-packages/installer/bundle/config/ytt/_ytt_lib/infrastructure/minikube/functions.star
@@ -16,3 +16,20 @@ end
 def isClusterPackageExplicitDisabled(package):
   return not isClusterPackageEnabled(package)
 end
+
+def xgetattr(object, path, default=None):
+  def _lookup(object, key, default=None):
+    keys = key.split(".")
+    value = default
+    for key in keys:
+      value = getattr(object, key, None)
+      if value == None:
+        return default
+      end
+      object = value
+    end
+    return value
+  end
+
+  return _lookup(object, path, default)
+end

--- a/carvel-packages/installer/bundle/config/ytt/_ytt_lib/infrastructure/openshift/10-default-settings-for-provider.yaml
+++ b/carvel-packages/installer/bundle/config/ytt/_ytt_lib/infrastructure/openshift/10-default-settings-for-provider.yaml
@@ -1,6 +1,6 @@
 #@ load("@ytt:data", "data")
 #@ load("@ytt:overlay", "overlay")
-#@ load("functions.star", "isClusterPackageEnableByDefault")
+#@ load("functions.star", "xgetattr", "isClusterPackageEnableByDefault")
 
 #! This file contains default values for the custom infrastructure provider.
 #! These are the values that will be set if not overridden by the user.
@@ -28,6 +28,4 @@ clusterPackages:
     settings: {}
   educates:
     enabled: #@ isClusterPackageEnableByDefault("educates")
-    settings:
-      clusterSecurity:
-        policyEngine: security-context-constraints
+    settings: #@ xgetattr(data.values, "clusterPackages.educates.settings")

--- a/carvel-packages/installer/bundle/config/ytt/_ytt_lib/infrastructure/openshift/10-default-settings-for-provider.yaml
+++ b/carvel-packages/installer/bundle/config/ytt/_ytt_lib/infrastructure/openshift/10-default-settings-for-provider.yaml
@@ -1,7 +1,6 @@
 #@ load("@ytt:data", "data")
 #@ load("@ytt:overlay", "overlay")
 #@ load("functions.star", "isClusterPackageEnableByDefault")
-#@ load("functions.star", "isClusterPackageExplicitDisabled")
 
 #! This file contains default values for the custom infrastructure provider.
 #! These are the values that will be set if not overridden by the user.

--- a/carvel-packages/installer/bundle/config/ytt/_ytt_lib/infrastructure/openshift/educates.lib.yaml
+++ b/carvel-packages/installer/bundle/config/ytt/_ytt_lib/infrastructure/openshift/educates.lib.yaml
@@ -75,7 +75,7 @@ trainingPortal:
       username: #@ data.values.trainingPortal.credentials.admin.username
       #@ if/end hasattr(data.values.trainingPortal.credentials.admin, "password") and data.values.trainingPortal.credentials.admin.password != None:
       password: #@ data.values.trainingPortal.credentials.admin.password
-    #@ if/end hasattr(data.values.trainingPortal.credentials, "robot") and data.values.trainingPortal.credentials.admin != None:
+    #@ if/end hasattr(data.values.trainingPortal.credentials, "robot") and data.values.trainingPortal.credentials.robot != None:
     robot:
       #@ if/end hasattr(data.values.trainingPortal.credentials.robot, "username") and data.values.trainingPortal.credentials.robot.username != None:
       username: #@ data.values.trainingPortal.credentials.robot.username

--- a/carvel-packages/installer/bundle/config/ytt/_ytt_lib/infrastructure/openshift/educates.lib.yaml
+++ b/carvel-packages/installer/bundle/config/ytt/_ytt_lib/infrastructure/openshift/educates.lib.yaml
@@ -60,9 +60,9 @@ clusterStorage:
   group: #@ data.values.clusterStorage.group
 #@ if/end hasattr(data.values, "clusterSecrets") and data.values.clusterSecrets != None:
 clusterSecrets: #@ data.values.clusterSecrets
-#! Should not allow cluster security policy engine default to be overridden as must be set to security-context-constraints
-#! #@ if/end hasattr(data.values, "clusterSecurity") and data.values.clusterSecurity != None:
-#! clusterSecurity: #@ data.values.clusterSecurity
+#! Policy engine must always be security-context-constraints on openshift
+clusterSecurity:
+  policyEngine: security-context-constraints
 #@ if/end hasattr(data.values, "workshopSecurity") and data.values.workshopSecurity != None:
 workshopSecurity: #@ data.values.workshopSecurity
 #@ if/end hasattr(data.values, "trainingPortal") and data.values.trainingPortal != None:

--- a/carvel-packages/installer/bundle/config/ytt/_ytt_lib/infrastructure/openshift/functions.star
+++ b/carvel-packages/installer/bundle/config/ytt/_ytt_lib/infrastructure/openshift/functions.star
@@ -16,3 +16,20 @@ end
 def isClusterPackageExplicitDisabled(package):
   return not isClusterPackageEnabled(package)
 end
+
+def xgetattr(object, path, default=None):
+  def _lookup(object, key, default=None):
+    keys = key.split(".")
+    value = default
+    for key in keys:
+      value = getattr(object, key, None)
+      if value == None:
+        return default
+      end
+      object = value
+    end
+    return value
+  end
+
+  return _lookup(object, path, default)
+end

--- a/carvel-packages/installer/bundle/config/ytt/_ytt_lib/infrastructure/vcluster/10-default-settings-for-provider.yaml
+++ b/carvel-packages/installer/bundle/config/ytt/_ytt_lib/infrastructure/vcluster/10-default-settings-for-provider.yaml
@@ -1,6 +1,6 @@
 #@ load("@ytt:data", "data")
 #@ load("@ytt:overlay", "overlay")
-#@ load("functions.star", "isClusterPackageEnableByDefault")
+#@ load("functions.star", "xgetattr", "isClusterPackageEnableByDefault")
 
 #! This file contains default values for the custom infrastructure provider.
 #! These are the values that will be set if not overridden by the user.
@@ -28,4 +28,4 @@ clusterPackages:
     settings: {}
   educates:
     enabled: #@ isClusterPackageEnableByDefault("educates")
-    settings: {}
+    settings: #@ xgetattr(data.values, "clusterPackages.educates.settings")

--- a/carvel-packages/installer/bundle/config/ytt/_ytt_lib/infrastructure/vcluster/educates.lib.yaml
+++ b/carvel-packages/installer/bundle/config/ytt/_ytt_lib/infrastructure/vcluster/educates.lib.yaml
@@ -74,7 +74,7 @@ trainingPortal:
       username: #@ data.values.trainingPortal.credentials.admin.username
       #@ if/end hasattr(data.values.trainingPortal.credentials.admin, "password") and data.values.trainingPortal.credentials.admin.password != None:
       password: #@ data.values.trainingPortal.credentials.admin.password
-    #@ if/end hasattr(data.values.trainingPortal.credentials, "robot") and data.values.trainingPortal.credentials.admin != None:
+    #@ if/end hasattr(data.values.trainingPortal.credentials, "robot") and data.values.trainingPortal.credentials.robot != None:
     robot:
       #@ if/end hasattr(data.values.trainingPortal.credentials.robot, "username") and data.values.trainingPortal.credentials.robot.username != None:
       username: #@ data.values.trainingPortal.credentials.robot.username

--- a/carvel-packages/installer/bundle/config/ytt/_ytt_lib/infrastructure/vcluster/functions.star
+++ b/carvel-packages/installer/bundle/config/ytt/_ytt_lib/infrastructure/vcluster/functions.star
@@ -16,3 +16,20 @@ end
 def isClusterPackageExplicitDisabled(package):
   return not isClusterPackageEnabled(package)
 end
+
+def xgetattr(object, path, default=None):
+  def _lookup(object, key, default=None):
+    keys = key.split(".")
+    value = default
+    for key in keys:
+      value = getattr(object, key, None)
+      if value == None:
+        return default
+      end
+      object = value
+    end
+    return value
+  end
+
+  return _lookup(object, path, default)
+end

--- a/carvel-packages/installer/scenarios/eks/test-eks-scenario-01/expected.yaml
+++ b/carvel-packages/installer/scenarios/eks/test-eks-scenario-01/expected.yaml
@@ -27,7 +27,8 @@ clusterPackages:
       aws:
         args:
           domain_filter: example.com
-          txt_owner_id: educates
+          policy: sync
+          txt_owner_id: educates.example.com
   certs:
     enabled: true
     settings:

--- a/carvel-packages/installer/scenarios/eks/test-eks-scenario-01b/expected.yaml
+++ b/carvel-packages/installer/scenarios/eks/test-eks-scenario-01b/expected.yaml
@@ -27,7 +27,8 @@ clusterPackages:
       aws:
         args:
           domain_filter: educates.example.com
-          txt_owner_id: educates
+          policy: sync
+          txt_owner_id: educates.example.com
   certs:
     enabled: true
     settings:

--- a/carvel-packages/installer/scenarios/eks/test-eks-scenario-02/expected.yaml
+++ b/carvel-packages/installer/scenarios/eks/test-eks-scenario-02/expected.yaml
@@ -27,7 +27,8 @@ clusterPackages:
       aws:
         args:
           domain_filter: example.com
-          txt_owner_id: educates
+          policy: sync
+          txt_owner_id: educates.example.com
   certs:
     enabled: true
     settings:

--- a/carvel-packages/installer/scenarios/eks/test-eks-scenario-04/expected.yaml
+++ b/carvel-packages/installer/scenarios/eks/test-eks-scenario-04/expected.yaml
@@ -27,7 +27,8 @@ clusterPackages:
       aws:
         args:
           domain_filter: example.com
-          txt_owner_id: educates
+          policy: sync
+          txt_owner_id: educates.example.com
   certs:
     enabled: true
     settings:

--- a/carvel-packages/installer/scenarios/eks/test-eks-scenario-04b/expected.yaml
+++ b/carvel-packages/installer/scenarios/eks/test-eks-scenario-04b/expected.yaml
@@ -27,7 +27,8 @@ clusterPackages:
       aws:
         args:
           domain_filter: example.com
-          txt_owner_id: educates
+          policy: sync
+          txt_owner_id: educates.example.com
   certs:
     enabled: true
     settings:

--- a/carvel-packages/installer/scenarios/eks/test-eks-scenario-04c/expected.yaml
+++ b/carvel-packages/installer/scenarios/eks/test-eks-scenario-04c/expected.yaml
@@ -27,7 +27,8 @@ clusterPackages:
       aws:
         args:
           domain_filter: example.com
-          txt_owner_id: educates
+          policy: sync
+          txt_owner_id: educates.example.com
   certs:
     enabled: true
     settings:

--- a/carvel-packages/installer/scenarios/eks/test-eks-scenario-04d/expected.yaml
+++ b/carvel-packages/installer/scenarios/eks/test-eks-scenario-04d/expected.yaml
@@ -27,7 +27,8 @@ clusterPackages:
       aws:
         args:
           domain_filter: example.com
-          txt_owner_id: educates
+          policy: sync
+          txt_owner_id: educates.example.com
   certs:
     enabled: true
     settings:

--- a/carvel-packages/installer/scenarios/generic/README.md
+++ b/carvel-packages/installer/scenarios/generic/README.md
@@ -1,3 +1,3 @@
-# vcluster
-For vcluster we only allow the opinionated configuration for the packages, so, not settings are allowed
-and no enablong/disabling of individual packages permitted.
+# generic
+For generic contour will never be installed, educates can not be skipped and the rest of the packages can be
+customised.

--- a/carvel-packages/installer/scenarios/gke/test-gke-scenario-01/expected.yaml
+++ b/carvel-packages/installer/scenarios/gke/test-gke-scenario-01/expected.yaml
@@ -27,8 +27,9 @@ clusterPackages:
       gcp:
         args:
           project: my-project
+          policy: sync
           domain_filter: example.com
-          txt_owner_id: educates
+          txt_owner_id: educates.example.com
   certs:
     enabled: true
     settings:

--- a/carvel-packages/installer/scenarios/gke/test-gke-scenario-02/expected.yaml
+++ b/carvel-packages/installer/scenarios/gke/test-gke-scenario-02/expected.yaml
@@ -27,8 +27,9 @@ clusterPackages:
       gcp:
         args:
           project: my-project
+          policy: sync
           domain_filter: example.com
-          txt_owner_id: educates
+          txt_owner_id: educates.example.com
   certs:
     enabled: true
     settings:

--- a/carvel-packages/installer/scenarios/gke/test-gke-scenario-04/expected.yaml
+++ b/carvel-packages/installer/scenarios/gke/test-gke-scenario-04/expected.yaml
@@ -27,8 +27,9 @@ clusterPackages:
       gcp:
         args:
           project: my-project
+          policy: sync
           domain_filter: example.com
-          txt_owner_id: educates
+          txt_owner_id: educates.example.com
   certs:
     enabled: true
     settings:

--- a/carvel-packages/installer/scenarios/gke/test-gke-scenario-04b/expected.yaml
+++ b/carvel-packages/installer/scenarios/gke/test-gke-scenario-04b/expected.yaml
@@ -27,8 +27,9 @@ clusterPackages:
       gcp:
         args:
           project: my-project
+          policy: sync
           domain_filter: example.com
-          txt_owner_id: educates
+          txt_owner_id: educates.example.com
   certs:
     enabled: true
     settings:

--- a/carvel-packages/installer/scenarios/gke/test-gke-scenario-04c/expected.yaml
+++ b/carvel-packages/installer/scenarios/gke/test-gke-scenario-04c/expected.yaml
@@ -27,8 +27,9 @@ clusterPackages:
       gcp:
         args:
           project: my-project
+          policy: sync
           domain_filter: example.com
-          txt_owner_id: educates
+          txt_owner_id: educates.example.com
   certs:
     enabled: true
     settings:

--- a/carvel-packages/installer/scenarios/gke/test-gke-scenario-04d/expected.yaml
+++ b/carvel-packages/installer/scenarios/gke/test-gke-scenario-04d/expected.yaml
@@ -27,8 +27,9 @@ clusterPackages:
       gcp:
         args:
           project: my-project
+          policy: sync
           domain_filter: example.com
-          txt_owner_id: educates
+          txt_owner_id: educates.example.com
   certs:
     enabled: true
     settings:


### PR DESCRIPTION
Add some fixes to the Carvel installer.
These fixes were detected on a functionality scan, and are located in providers not commonly used, but still, wrong.