### PR TITLE
Dynamic favicon

### DIFF
--- a/training-portal/src/project/apps/workshops/contexts.py
+++ b/training-portal/src/project/apps/workshops/contexts.py
@@ -11,6 +11,7 @@ def portal(request):
     context = {}
     context["portal_title"] = settings.PORTAL_TITLE
     context["portal_logo"] = settings.PORTAL_LOGO
+    context["portal_favicon"] = settings.PORTAL_FAVICON
     context["google_tracking_id"] = settings.GOOGLE_TRACKING_ID
     context["clarity_tracking_id"] = settings.CLARITY_TRACKING_ID
     context["amplitude_tracking_id"] = settings.AMPLITUDE_TRACKING_ID

--- a/training-portal/src/project/apps/workshops/templates/workshops/session.html
+++ b/training-portal/src/project/apps/workshops/templates/workshops/session.html
@@ -9,7 +9,11 @@
     <link rel="stylesheet" href="{% static "styles/bootstrap.min.css" %}" crossorigin="anonymous">
     <link rel="stylesheet" href="{% static "workshops/styles/session.css" %}" crossorigin="anonymous">
     <link rel="stylesheet" href="{% static "workshops/theme/training-portal.css" %}" crossorigin="anonymous">
+    {% if portal_favicon %}
+    <link rel="shortcut icon" href="{{ portal_favicon | escape }}"/>
+    {% else %}
     <link rel="shortcut icon" href="{% static "images/favicon.ico" %}"/>
+    {% endif %}
 
     {% if google_tracking_id %}
     <script async src="https://www.googletagmanager.com/gtag/js?id={{ google_tracking_id }}" nonce={{ request.csp_nonce }}></script>

--- a/training-portal/src/project/settings.py
+++ b/training-portal/src/project/settings.py
@@ -179,6 +179,11 @@ if os.path.exists(portal_log_path):
     with open(portal_log_path) as fp:
         PORTAL_LOGO = fp.read()
 
+PORTAL_FAVICON = None
+
+if os.path.exists("/opt/app-root/static/theme/favicon.ico"):
+    PORTAL_FAVICON = "/static/workshops/theme/favicon.ico"
+
 GOOGLE_TRACKING_ID = os.environ.get("GOOGLE_TRACKING_ID", "")
 CLARITY_TRACKING_ID = os.environ.get("CLARITY_TRACKING_ID", "")
 AMPLITUDE_TRACKING_ID = os.environ.get("AMPLITUDE_TRACKING_ID", "")

--- a/training-portal/src/project/templates/project-base.html
+++ b/training-portal/src/project/templates/project-base.html
@@ -9,7 +9,11 @@
     {% endblock %}
     <link rel="stylesheet" href="{% static "styles/bootstrap.min.css" %}" crossorigin="anonymous">
     <link rel="stylesheet" href="{% static "styles/project.css" %}" crossorigin="anonymous">
+    {% if portal_favicon %}
+    <link rel="shortcut icon" href="{{ portal_favicon | escape }}"/>
+    {% else %}
     <link rel="shortcut icon" href="{% static "images/favicon.ico" %}"/>
+    {% endif %}
     <title>{{ portal_title | escape }}</title>
     {% block head_styles %}
     {% endblock %}

--- a/workshop-images/base-environment/opt/gateway/src/backend/modules/dashboard.ts
+++ b/workshop-images/base-environment/opt/gateway/src/backend/modules/dashboard.ts
@@ -35,6 +35,10 @@ function load_finished_html() {
     return fs.readFileSync(html_pathname, "utf8")
 }
 
+const favicon_url = fs.existsSync("/opt/eduk8s/theme/favicon.ico")
+    ? "/static/theme/favicon.ico"
+    : "/static/images/favicon.ico"
+
 export function setup_dashboard(app: express.Application, oauth2_client: any) {
     if (!config.enable_dashboard)
         return
@@ -91,6 +95,7 @@ export function setup_dashboard(app: express.Application, oauth2_client: any) {
         locals["workshop_head_html"] = load_head_html()
         locals["workshop_started_html"] = load_started_html()
         locals["workshop_finished_html"] = load_finished_html()
+        locals["favicon_url"] = favicon_url
 
         res.render("dashboard-page", locals)
     })

--- a/workshop-images/base-environment/opt/gateway/src/backend/modules/terminals.ts
+++ b/workshop-images/base-environment/opt/gateway/src/backend/modules/terminals.ts
@@ -1,4 +1,5 @@
 import * as express from "express"
+import * as fs from "fs"
 import * as http from "http"
 import * as path from "path"
 import * as WebSocket from "ws"
@@ -9,6 +10,10 @@ import * as pty from "node-pty"
 import { IPty } from "node-pty"
 
 const BASEDIR = path.dirname(path.dirname(path.dirname(__dirname)))
+
+const favicon_url = fs.existsSync("/opt/eduk8s/theme/favicon.ico")
+    ? "/static/theme/favicon.ico"
+    : "/static/images/favicon.ico"
 
 enum TerminalsPacketType {
     HELLO,
@@ -387,6 +392,6 @@ export function setup_terminals(app: express.Application, server: http.Server) {
     app.get("/terminal/session/:session_id", (req, res) => {
         let session_id = req.params.session_id || "1"
 
-        res.render("terminal-page", { session_id: session_id })
+        res.render("terminal-page", { session_id: session_id, favicon_url: favicon_url })
     })
 }

--- a/workshop-images/base-environment/opt/gateway/src/backend/views/dashboard-page.pug
+++ b/workshop-images/base-environment/opt/gateway/src/backend/views/dashboard-page.pug
@@ -6,7 +6,7 @@ html.no-scrolling
         link(rel="stylesheet", href="/static/fontawesome/css/all.min.css")
         link(rel="stylesheet", href="/static/styles/educates.css")
         link(rel="stylesheet", href="/static/theme/workshop-dashboard.css")
-        link(rel="shortcut icon", href="/static/images/favicon.ico") 
+        link(rel="shortcut icon", href=favicon_url)
 
         if workshop_head_html
             != workshop_head_html

--- a/workshop-images/base-environment/opt/gateway/src/backend/views/terminal-page.pug
+++ b/workshop-images/base-environment/opt/gateway/src/backend/views/terminal-page.pug
@@ -3,7 +3,7 @@ html
         link(rel="stylesheet", href="/static/xterm/css/xterm.css")
         link(rel="stylesheet", href="/static/bootstrap/css/bootstrap.css")
         link(rel="stylesheet", href="/static/styles/educates.css")
-        link(rel="shortcut icon", href="/static/images/favicon.ico")
+        link(rel="shortcut icon", href=favicon_url)
 
     body
         div.terminal(data-endpoint-id=`${endpoint_id}` data-session-id=`${session_id}` data-default-terminal="true")

--- a/workshop-images/base-environment/opt/renderer/src/backend/modules/routes.ts
+++ b/workshop-images/base-environment/opt/renderer/src/backend/modules/routes.ts
@@ -64,6 +64,10 @@ function load_head_html() {
     return fs.readFileSync(html_pathname, "utf8")
 }
 
+const favicon_url = fs.existsSync("/opt/eduk8s/theme/favicon.ico")
+    ? "/workshop/static/theme/favicon.ico"
+    : "/workshop/static/images/favicon.ico"
+
 router.get("/workshop/content/:pathname(*)", async function (req, res, next) {
     // Only allow a .html extension if an extension is supplied with the
     // request path. This is for compatability with previous rendering system.
@@ -97,6 +101,7 @@ router.get("/workshop/content/:pathname(*)", async function (req, res, next) {
                     module: module,
                     modules: modules,
                     workshop_head_html: load_head_html(),
+                    favicon_url: favicon_url,
                 }
 
                 return res.render("content-page", options)

--- a/workshop-images/base-environment/opt/renderer/src/backend/views/content-page.pug
+++ b/workshop-images/base-environment/opt/renderer/src/backend/views/content-page.pug
@@ -14,7 +14,7 @@ html
         link(rel="stylesheet", href=`/workshop/static/styles/educates-${module.format}.css`)
         link(rel="stylesheet", href="/workshop/static/theme/workshop-instructions.css")
 
-        link(rel="shortcut icon", href="/workshop/static/images/favicon.ico")
+        link(rel="shortcut icon", href=favicon_url)
 
         if workshop_head_html
             != workshop_head_html


### PR DESCRIPTION
This PR helps users to change the favicon.

Simply build and deploy it on your educates setup and encode your favorite icon in secret. (wait is that why we call it favicon ?!?!)
```
kubectl create secret generic frozen-theme \
  --namespace educates-cli-ui \
  --from-file=favicon.ico=favicon.ico \
  --dry-run=client -o yaml | kubectl apply -f -
```

You can also embed in the default theme or at the installation step to make it global.

Fixes: https://github.com/educates/educates-training-platform/issues/488