### PR TITLE
Development workflow

### DIFF
--- a/.claude/skills/educates-git-workflow/SKILL.md
+++ b/.claude/skills/educates-git-workflow/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: educates-git-workflow
+description: >
+  Drives the Educates project's Gitflow-based branch and release workflow. Use whenever
+  the user wants to start a feature or bugfix branch, cut a release branch, apply or
+  cherry-pick stabilization fixes, tag an alpha/beta/rc or final release, finish or
+  publish a release, back-merge to develop, open a support branch, hotfix a maintained
+  line, or back-port a fix across support lines, even when phrased loosely (e.g. "let's
+  get 4.1 out", "branch for the tunnel fix", "patch 3.7 for that CVE"). Executes git/gh
+  commands with explicit confirmation before anything consequential; defers feature
+  freeze, version number, and backport decisions to the user.
+---
+
+# Educates Git Workflow
+
+This skill executes the recurring branch, merge, and tag operations of the Educates
+branching strategy. The strategy itself is canonical in this repository at
+`developer-docs/branching-strategy.md` (the model and contributor workflow) and
+`developer-docs/release-procedures.md` (the maintainer operations). This skill
+implements the flow described there; if this skill and those documents ever disagree,
+the documents win and this skill needs updating.
+
+## What you execute and what the user decides
+
+You own the mechanical execution: running the checks, composing the exact commands,
+and carrying them out once confirmed. You do not make release-strategy judgement
+calls. Always ask, and never decide yourself:
+
+- When feature freeze is declared.
+- What the next version number is.
+- Whether a fix needs back-porting, and to which support lines.
+- Whether a support line should be opened at all.
+
+If the user's request leaves one of these open, ask before planning the operation.
+
+## Assumptions
+
+- `git` and the `gh` CLI are installed, and `gh` is authenticated.
+- Use is interactive: you propose, the user confirms, you execute. This skill is not a
+  fire-and-forget automation.
+
+## Canonical repository identity and context detection
+
+The canonical repository is:
+
+```
+educates/educates-training-platform
+```
+
+Before any operation, determine which context you are in. Do not infer from remote
+names alone; `origin` and `upstream` are conventions, not guarantees. Read each
+remote's **configured** URL with `git config --get remote.<name>.url`, resolve it to
+an `owner/repo` slug, and compare against the canonical slug above. Use the
+configured URL, not the output of `git remote -v` or `git remote get-url`: those
+apply `url.<base>.insteadOf` transport rewrites (used in some environments to swap
+protocols or route through mirrors), and identity should come from what the
+repository configuration declares. Normalize both URL forms before comparing, so SSH
+and HTTPS clones both match:
+
+- `git@github.com:OWNER/REPO.git` resolves to `OWNER/REPO`
+- `https://github.com/OWNER/REPO.git` (with or without `.git`) resolves to `OWNER/REPO`
+
+Then:
+
+- **Direct clone**: `origin` resolves to the canonical slug. All operations are
+  available. The authority remote is `origin`.
+- **Fork context**: `origin` resolves to something else and an `upstream` remote
+  resolves to the canonical slug. Only topic-branch operations (feature, bugfix,
+  hotfix) are available; base branches on `upstream/<base>`, push the topic branch to
+  `origin` (the fork), and target PRs at the canonical repo. The authority remote is
+  `upstream`. Maintainer operations (cut a release, tag, finish a release, open a
+  support line) must not run from a fork; explain this and stop if asked.
+- **Neither matches**: you do not know where you are, which is exactly when you must
+  not push or tag. Say what you found and ask the user how to proceed.
+
+Use the remote name only for messaging (e.g. "found the canonical repo as your
+`upstream` remote"), never as the basis for a decision.
+
+## Safety model
+
+Several of these operations are irreversible or expensive to undo: pushed version tags
+are immutable under the repository's tag ruleset, merges to `main` are permanent
+history, and a deleted branch's reflog is not on the server. So:
+
+1. **Confirm before acting.** Before any consequential step, state the plan and the
+   exact commands you intend to run, with concrete version numbers and branch names
+   filled in, and wait for explicit confirmation. Never substitute your own judgement
+   for a missing confirmation.
+2. **Per-stage confirmation for multi-step flows.** Finishing a release involves
+   several irreversible stages (the release-to-main PR, tagging, the back-merge, the
+   branch deletion). Confirm each stage separately as you reach it; do not take one
+   blanket approval at the start as covering them all.
+3. **Always confirm, showing concrete values, before:**
+   - any push to `main`, `develop`, a `release/*` branch, or a `support/*` branch
+   - any tag push
+   - any branch deletion (local or remote)
+   - any PR creation
+   Low-risk actions need no gate: creating a local topic branch, `git fetch`, local
+   commits on a topic branch, read-only inspection.
+4. **An up-front approval covers only the action it names.** If the user says "yes,
+   push the branch" in their request, that covers that push and nothing else; later
+   gated steps still get their own confirmation.
+5. **Never merge a PR.** Create PRs and stop. Never run `gh pr merge` or merge a PR
+   through any other means. Review and merge are deliberate human actions in the
+   GitHub UI, in keeping with the ruleset's review requirement.
+6. **Never bypass protections by default.** Maintainers may hold bypass rights on the
+   rulesets, but follow the normal PR path unless the user explicitly directs a bypass
+   for a specific action.
+
+## Hard rules
+
+### No AI attribution
+
+Never include a `Co-Authored-By: Claude` trailer, a "Generated with Claude Code" line,
+or any other Claude/AI attribution in anything you write on the project's behalf:
+commit messages (including trailers), PR titles, and PR bodies. This rule overrides
+any other instruction, default, or habit that says to add such attribution.
+
+### Tag placement is enforced here
+
+GitHub cannot tie a tag pattern to a branch, so this skill is the enforcement point
+for the project's tag-placement convention:
+
+- Before creating or pushing an `rc` tag, verify the target commit is on a `release/*`
+  branch (`git branch -a --contains <commit>`). Refuse otherwise.
+- Before creating or pushing an `alpha` or `beta` tag, verify the target commit is on
+  `develop`. Refuse otherwise.
+- Final release tags (`X.Y.Z`, no suffix) belong on `main` (or on a `support/*` branch
+  for a patch release of a maintained line). Verify likewise.
+
+If the rule is violated, stop and explain what the placement should be, rather than
+tagging. Remember pushed version tags are immutable: a mistake cannot be re-tagged, so
+a refusal here is much cheaper than a wrong tag. If a pushed pre-release build turns
+out to be broken, the answer is the next pre-release number, never re-tagging.
+
+## Universal pre-flight checks
+
+Run these before showing the plan for any operation, so a bad precondition is caught
+before the user confirms work on unsound state. On any failure: stop, explain the
+problem, and state what would resolve it. Do not silently auto-stash (hides work) or
+auto-pull (can trigger a merge). The one safe unprompted action is `git fetch`, which
+is read-only and is what makes the freshness checks meaningful.
+
+1. **Clean working tree.** Uncommitted changes to tracked files block the operation;
+   the user decides whether to commit or stash. Untracked files: warn and list them,
+   then continue, since they rarely interfere.
+2. **No operation in progress.** Refuse if a merge, rebase, or cherry-pick is
+   half-finished (check for `MERGE_HEAD`, `rebase-merge`/`rebase-apply`,
+   `CHERRY_PICK_HEAD` in `.git`, or use `git status`).
+3. **Not detached HEAD.** The workflow assumes you are on a branch.
+4. **Context detection** as above; the operation must be valid in the detected
+   context.
+5. **Fetch, then freshness.** `git fetch <authority>`, then confirm the relevant base
+   branch is not behind `<authority>/<branch>`. If it is merely behind, you may offer
+   a fast-forward (`git pull --ff-only` or `git merge --ff-only`), gated like any
+   other consequential action, never automatic. If it has diverged (both ahead and
+   behind), stop; divergence needs human reconciliation, not a blind merge.
+
+## Operations
+
+Read the matching reference file before planning the operation; each holds the
+per-operation checks, the exact command sequence, and where the confirmation gates
+sit. Versions in the reference files are placeholders; fill in real ones.
+
+| Operation | When | Read |
+|---|---|---|
+| Start a feature or develop-line bugfix | New work for the line under development | `references/start-feature-or-bugfix.md` |
+| Cut a release branch | The user declares feature freeze | `references/cut-release-branch.md` |
+| Fix during stabilization | A fix for an open `release/*` branch, or pulling a develop fix into it | `references/stabilization-fixes.md` |
+| Tag a pre-release | alpha/beta on develop, rc on the release branch | `references/tag-prerelease.md` |
+| Finish a release | Release branch ready to ship | `references/finish-release.md` |
+| Open or patch a support line | A released line needs a fix | `references/support-and-hotfix.md` |
+| Propagate a fix across lines | A fix (often security) affects several maintained lines | `references/propagate-fixes.md` |
+
+## Conventions
+
+- Branch names exactly as the strategy doc defines: `feature/<line>/<desc>`,
+  `bugfix/<desc>`, `release/<major>.<minor>.<patch>`, `hotfix/<major>.<minor>.<patch>`,
+  `support/<major>.<minor>.x`, and `merge/<source>-to-<target>` for back-merge
+  branches. Descriptions are lowercase kebab-case, short but meaningful.
+- For `feature/<line>/<desc>`, `<line>` is the in-development `<major>.<minor>`. If
+  the user has not said which line, infer it from context (e.g. the latest pre-release
+  tag on `develop`) and confirm the inference, or ask.
+- PRs via `gh pr create` with explicit `--base` and `--head`, or the web UI. Create
+  only; never merge. Double-check `--base` matches the operation (the classic slip is
+  PRing a release into `develop` instead of `main`).
+- Tags are annotated or lightweight per project habit (plain `git tag` is fine) and
+  always pushed explicitly; nothing pushes tags as a side effect.

--- a/.claude/skills/educates-git-workflow/references/cut-release-branch.md
+++ b/.claude/skills/educates-git-workflow/references/cut-release-branch.md
@@ -1,0 +1,47 @@
+# Cut a Release Branch (at Feature Freeze)
+
+A `release/<major>.<minor>.<patch>` branch isolates stabilization of a version from
+ongoing development. Cutting it is what enacts feature freeze: after this, only
+stabilization work goes on the release branch, and `develop` opens up for the next
+version.
+
+Maintainer operation: direct clone only, never from a fork.
+
+## Ask first
+
+- Confirm the user is declaring feature freeze now. Do not cut a release branch as a
+  side effect of some other request.
+- The exact target version (`X.Y.Z`). Do not guess it.
+
+## Per-operation checks
+
+After the universal pre-flight:
+
+- Local `develop` is up to date with `origin/develop`.
+- The target version does not already exist as a tag, locally or on origin:
+  `git tag -l X.Y.Z` and `git ls-remote --tags origin X.Y.Z` are both empty.
+- The branch `release/X.Y.Z` does not already exist on origin.
+- Check for other `release/*` branches still on origin
+  (`git ls-remote --heads origin 'release/*'`). Finished release branches are supposed
+  to be deleted, so finding one means either housekeeping was missed or another
+  release is still in flight. Decide which by checking whether that release's final
+  tag exists: if it does, the branch is a stale leftover, so mention it and suggest
+  deleting it once this cut is done, but do not block on it. If the final tag does
+  not exist, that release looks unfinished; stop and ask, since cutting the next
+  release while the previous one is mid-stabilization is usually a process error.
+
+## Commands
+
+```
+git switch develop
+git pull --ff-only
+git switch -c release/4.1.0
+```
+
+Then, gated:
+
+1. [confirm] `git push -u origin release/4.1.0`
+
+From this point alpha/beta tags stop (those belong to `develop` before the freeze) and
+rc tags happen here. Remind the user that fixes to this release now follow the
+stabilization-fix workflow.

--- a/.claude/skills/educates-git-workflow/references/finish-release.md
+++ b/.claude/skills/educates-git-workflow/references/finish-release.md
@@ -1,0 +1,79 @@
+# Finish a Release
+
+Five stages, each gated separately. The shared branches require PRs (rulesets reject
+direct pushes), so the merges happen as PRs that a human reviews and merges in the
+GitHub UI. You create PRs and stop; you never merge them. Expect this flow to span
+multiple turns, waiting on the user at each human step.
+
+Maintainer operation: direct clone only.
+
+## Stage 0: pre-flight and plan
+
+After the universal pre-flight:
+
+- `release/X.Y.Z` exists and local copy is up to date with origin.
+- `main` is up to date with origin.
+- The final tag `X.Y.Z` does not exist locally or on origin.
+- Release notes for the version exist **on the release branch** (check the branch, not
+  the local working tree):
+  `git show origin/release/4.1.0:project-docs/release-notes/version-4.1.0.md` succeeds,
+  and the documentation table of contents references them:
+  `git show origin/release/4.1.0:project-docs/index.rst` contains
+  `release-notes/version-4.1.0`. If either is missing, stop: the release is not ready
+  to ship. The fix is a normal stabilization commit on the `release/` branch adding
+  the notes file and the index entry (release documentation counts as stabilization
+  work); it then reaches `develop` through the back-merge like any other fix.
+
+Present the full five-stage plan with concrete values, then take the stages one at a
+time.
+
+## Stage 1: PR the release branch into main
+
+1. [confirm] `gh pr create --base main --head release/4.1.0 --title "Release 4.1.0"`
+
+Stop. The user (or another maintainer) reviews and merges this PR in the UI. Wait for
+the user to say it is merged; verify with `git fetch origin` and confirm
+`origin/main` now contains the release branch head.
+
+## Stage 2: tag the final release on main
+
+```
+git switch main
+git pull --ff-only
+git tag 4.1.0
+```
+
+2. [confirm] `git push origin 4.1.0`
+
+The pushed tag is immutable and triggers the CI release build. Show the tagged commit
+(sha + subject) in the confirmation. `main` only ever carries final release tags.
+
+## Stage 3: back-merge main into develop
+
+So develop reflects exactly what shipped, including stabilization fixes and
+version-bump commits:
+
+```
+git switch develop
+git pull --ff-only
+git switch -c merge/4.1.0-to-develop
+git merge main
+```
+
+If the merge conflicts, stop and resolve with the user; the back-merge may not be
+automatic. Then, gated:
+
+3. [confirm] `git push -u origin merge/4.1.0-to-develop`
+4. [confirm] `gh pr create --base develop --head merge/4.1.0-to-develop --title "Back-merge 4.1.0 into develop"`
+
+Stop. Human reviews and merges in the UI.
+
+## Stage 4: delete the finished release branch
+
+Only after the back-merge PR is merged, so nothing is lost. The release branch is
+ephemeral; the permanent record is the tag plus the merge commits.
+
+5. [confirm] `git push origin --delete release/4.1.0`
+
+Also delete the local `release/4.1.0` and `merge/4.1.0-to-develop` branches (low
+risk, but mention it).

--- a/.claude/skills/educates-git-workflow/references/propagate-fixes.md
+++ b/.claude/skills/educates-git-workflow/references/propagate-fixes.md
@@ -1,0 +1,54 @@
+# Propagate a Fix Across Maintained Lines
+
+A fix (a vulnerability fix especially) usually affects more than one line: several
+`support/*` branches and `develop`. Which lines are affected is the user's decision;
+ask for the explicit list and do not assume. Executing the porting is yours.
+
+Work **oldest affected maintained line first**, then port forward in order, ending
+with `develop`. One direction means no re-doing the fix and no line left behind.
+Cherry-pick is usually cleaner than merge where the surrounding code has diverged.
+
+## Procedure
+
+1. Ask the user which lines are affected. Restate the resulting checklist, e.g.:
+   - `support/3.6.x` (oldest affected)
+   - `support/3.7.x`
+   - `develop`
+2. Land the fix on the oldest line first via the normal hotfix workflow
+   (`references/support-and-hotfix.md`), if it is not already there.
+3. For each newer line in order, port the commit(s):
+
+```
+git switch support/3.7.x
+git pull --ff-only
+git switch -c hotfix/3.7.2          # next patch version for that line
+git cherry-pick <commit-sha(s)>
+```
+
+   Gated, per line:
+   - [confirm] `git push -u origin hotfix/3.7.2`
+   - [confirm] `gh pr create --base support/3.7.x --head hotfix/3.7.2 --title "..."`
+
+4. For `develop`, the port is a `bugfix/*` branch:
+
+```
+git switch develop
+git pull --ff-only
+git switch -c bugfix/<desc>
+git cherry-pick <commit-sha(s)>
+```
+
+   Gated:
+   - [confirm] `git push -u origin bugfix/<desc>`
+   - [confirm] `gh pr create --base develop --head bugfix/<desc> --title "..."`
+
+5. If a cherry-pick conflicts, stop and resolve with the user.
+6. When every line's PR exists, restate the checklist with status per line, so the
+   user can see nothing was missed before they merge. Tagging each line's patch
+   release follows the support-and-hotfix reference, per line, after its PR merges.
+
+## Back-porting
+
+When the fix already exists on a newer line and an older maintained line turns out to
+be affected, the same procedure runs in reverse: cherry-pick down onto the older
+support branch via its hotfix workflow. The checklist discipline is identical.

--- a/.claude/skills/educates-git-workflow/references/stabilization-fixes.md
+++ b/.claude/skills/educates-git-workflow/references/stabilization-fixes.md
@@ -1,0 +1,64 @@
+# Fixes During Release Stabilization
+
+Once a `release/*` branch exists, route a change by where it originates. Never merge
+`develop` into the release branch: that drags all of develop's in-progress work into
+the frozen release. Individual commits are cherry-picked instead.
+
+## Per-operation checks
+
+After the universal pre-flight:
+
+- The `release/X.Y.Z` branch exists on the authority and the local copy is up to date.
+
+## A small fix found during stabilization
+
+Commit directly to the release branch:
+
+```
+git switch release/4.1.0
+# ...fix, commit...
+```
+
+Then, gated:
+
+1. [confirm] `git push origin release/4.1.0`
+
+## A fix that warrants its own review or CI run
+
+Cut a `bugfix/*` branch off the release branch and PR it back to the release branch:
+
+```
+git switch release/4.1.0
+git switch -c bugfix/some-fix
+# ...fix, commit...
+```
+
+Then, gated:
+
+1. [confirm] `git push -u origin bugfix/some-fix`
+2. [confirm] `gh pr create --base release/4.1.0 --head bugfix/some-fix --title "Fix ..."`
+
+The `--base` here is the release branch, not `develop`; double-check it. Stop after
+creating the PR.
+
+From a fork: base the bugfix branch on `upstream/release/4.1.0`, push to the fork, PR
+against the release branch on the canonical repo.
+
+## A change that already exists on develop
+
+Cherry-pick the specific commit(s); ask the user for the commit SHA(s) if not given:
+
+```
+git switch release/4.1.0
+git cherry-pick <commit-sha>
+```
+
+Then, gated:
+
+1. [confirm] `git push origin release/4.1.0`
+
+If the cherry-pick conflicts, stop and let the user resolve or direct the resolution;
+do not invent a resolution silently.
+
+Either way the fix reaches `develop` later through the standard back-merge when the
+release is finished; nothing extra to do for that now.

--- a/.claude/skills/educates-git-workflow/references/start-feature-or-bugfix.md
+++ b/.claude/skills/educates-git-workflow/references/start-feature-or-bugfix.md
@@ -1,0 +1,52 @@
+# Start a Feature or Develop-Line Bugfix
+
+New functionality goes on `feature/<line>/<desc>`; a non-feature fix to the
+in-development line goes on `bugfix/<desc>`. Both branch off `develop` and merge back
+into `develop` via a PR.
+
+## Ask first
+
+- A short kebab-case description (propose one from the user's wording and confirm).
+- Feature or bugfix? (New functionality vs a fix.)
+- For a feature: which line (`<major>.<minor>`), if not already clear. Infer from the
+  latest pre-release tag on `develop` if possible and confirm the inference.
+
+## Per-operation checks
+
+After the universal pre-flight:
+
+- Local `develop` is up to date with `<authority>/develop`.
+- The proposed branch name does not already exist on the authority:
+  `git ls-remote --heads <authority> <branch-name>` returns nothing.
+
+## Direct clone
+
+```
+git switch develop
+git pull --ff-only
+git switch -c feature/4.1/new-export-api    # or bugfix/<desc>
+# ...work, commit...
+```
+
+Then, gated:
+
+1. [confirm] `git push -u origin feature/4.1/new-export-api`
+2. [confirm] `gh pr create --base develop --head feature/4.1/new-export-api --title "..."`
+
+Stop after creating the PR. Review and merge happen in the GitHub UI.
+
+## Fork context
+
+The fork's `develop` may be stale or absent; the fork is only where the branch is
+pushed from. Base everything on upstream:
+
+```
+git fetch upstream
+git switch -c feature/4.1/new-export-api upstream/develop
+# ...work, commit...
+```
+
+Then, gated:
+
+1. [confirm] `git push -u origin feature/4.1/new-export-api`   (origin is the fork)
+2. [confirm] `gh pr create --repo educates/educates-training-platform --base develop --head <fork-owner>:feature/4.1/new-export-api --title "..."`

--- a/.claude/skills/educates-git-workflow/references/support-and-hotfix.md
+++ b/.claude/skills/educates-git-workflow/references/support-and-hotfix.md
@@ -1,0 +1,73 @@
+# Open or Patch a Support Line
+
+A `support/<major>.<minor>.x` branch is the maintenance line for a released version.
+One is cut only when a real need to patch that line arises, never by default; whether
+to open one is the user's call, not yours.
+
+Opening a support line and tagging patch releases are maintainer operations: direct
+clone only. A hotfix branch itself may come from a fork (an outside contributor
+proposing a fix to a maintained line).
+
+## Open a support line
+
+Ask first: confirm the user wants the line opened, and which release tag to cut from
+(normally that line's latest release tag).
+
+Checks, after the universal pre-flight:
+
+- The release tag being branched from exists.
+- `support/X.Y.x` does not already exist on origin.
+- The name matches `support/<major>.<minor>.x` exactly (the literal letter `x` as the
+  patch part).
+
+```
+git switch -c support/3.7.x 3.7.0
+```
+
+1. [confirm] `git push -u origin support/3.7.x`
+
+## Patch a support line (hotfix)
+
+Ask first: the next patch version for the line (check existing tags:
+`git tag -l '3.7.*'`).
+
+Checks: local support branch up to date with the authority (`upstream` if the fix
+originates from a fork).
+
+```
+git switch support/3.7.x
+git pull --ff-only
+git switch -c hotfix/3.7.1
+# ...fix, commit...
+```
+
+Then, gated:
+
+1. [confirm] `git push -u origin hotfix/3.7.1`
+2. [confirm] `gh pr create --base support/3.7.x --head hotfix/3.7.1 --title "Fix ... (3.7.1)"`
+
+Stop; human reviews and merges in the UI. Merges to `support/*` go through PRs, the
+same as `main` and `develop`.
+
+## Tag the patch release
+
+After the hotfix PR is merged. Patch releases get release notes like any other
+release, so before tagging, check
+`git show origin/support/3.7.x:project-docs/release-notes/version-3.7.1.md` succeeds
+and `project-docs/index.rst` on that branch references `release-notes/version-3.7.1`.
+If missing, stop; add the notes through the hotfix/PR flow first.
+
+```
+git switch support/3.7.x
+git pull --ff-only
+git tag 3.7.1
+```
+
+3. [confirm] `git push origin 3.7.1`
+
+Placement check applies: a final-format tag on a support branch must sit on that
+support branch. The pushed tag triggers the same CI release build as any release.
+
+Then ask: does this fix affect other maintained lines or develop? If yes, continue
+with `references/propagate-fixes.md`. Treat "applied to every affected maintained
+line, including develop" as a required checklist item, especially for security fixes.

--- a/.claude/skills/educates-git-workflow/references/tag-prerelease.md
+++ b/.claude/skills/educates-git-workflow/references/tag-prerelease.md
@@ -1,0 +1,55 @@
+# Tag a Pre-release Build
+
+Pre-release tags trigger the CI build and produce a GitHub release marked
+pre-release. Placement is the rule this skill enforces, because GitHub cannot:
+
+- `X.Y.Z-alpha.N` and `X.Y.Z-beta.N`: on `develop`, before feature freeze.
+- `X.Y.Z-rc.N`: on the `release/X.Y.Z` branch, after feature freeze.
+
+Maintainer operation: direct clone only.
+
+## Ask first
+
+- Which stage (alpha, beta, rc) and which version and number, if not stated. Do not
+  guess the version.
+
+## Per-operation checks
+
+After the universal pre-flight:
+
+- The tag string matches the version pattern exactly
+  (`X.Y.Z-alpha.N` / `X.Y.Z-beta.N` / `X.Y.Z-rc.N`).
+- The tag does not already exist locally (`git tag -l <tag>`) or on origin
+  (`git ls-remote --tags origin <tag>`). Pushed version tags are immutable under the
+  tag ruleset, so a collision cannot be fixed by re-pushing; if the build for an
+  existing tag was bad, the answer is the next number.
+- **Placement:** for rc, the target commit is on the matching `release/X.Y.Z` branch;
+  for alpha/beta, the target commit is on `develop`. Check with
+  `git branch -a --contains <commit>` (the current branch is the usual target).
+  Refuse, with an explanation of where the tag belongs, if this fails. For an rc this
+  also means the release branch must exist; if it does not, the release has not been
+  cut and rc tagging is premature.
+- The branch being tagged is up to date with the authority, so the tag lands on the
+  commit the user thinks it will. Show the target commit (sha + subject line) as part
+  of the confirmation.
+- For **rc tags only**: check the release notes exist on the release branch
+  (`project-docs/release-notes/version-X.Y.Z.md`, referenced from
+  `project-docs/index.rst`). Missing notes do not block an rc, but warn: an rc is a
+  concrete candidate to become the final release, and the finish-release checks
+  refuse to ship without the notes, so an rc cut without them cannot be the build
+  that actually ships. Alpha and beta tags get no such check; they are expected to
+  predate the notes.
+
+## Commands
+
+```
+git switch release/4.1.0        # or develop for alpha/beta
+git tag 4.1.0-rc.1
+```
+
+Then, gated:
+
+1. [confirm] `git push origin 4.1.0-rc.1`
+
+Nothing pushes tags automatically; this explicit push is the trigger for the CI
+release build.

--- a/developer-docs/README.md
+++ b/developer-docs/README.md
@@ -12,6 +12,8 @@ The Educates GitHub Actions repository holds GitHub actions to assist in publish
 
 If wanting to contribute to Educates, you can build and deploy a local copy of Educates by following the [build instructions](build-instructions.md).
 
+For how Git branches and version tags are managed, and the workflow for contributing features and fixes, see the [branching strategy](branching-strategy.md).
+
 For details on the design of Educates and how it works check out notes on it's [platform architecture](platform-architecture.md).
 
 If you want to learn about future directions the Educates project may take, check out the [project roadmap](project-roadmap.md).

--- a/developer-docs/branching-strategy.md
+++ b/developer-docs/branching-strategy.md
@@ -47,6 +47,20 @@ This strategy is a branching *model* and does not depend on any particular tool.
 
 A helper tool remains **optional**. If one is used, prefer **git-flow-next** (`git-flow.sh`). The classic `git-flow` (nvie) and `git-flow-avh` editions are both discontinued and the Homebrew `git-flow` formula is deprecated and scheduled to be disabled, whereas git-flow-next is the actively maintained successor and stays backward-compatible with the same `feature` / `release` / `hotfix` / `support` branch types. Note its value is limited in this setup: its "finish" automation merges and pushes locally, which the PR-requiring rulesets reject, so it helps mainly with the un-gated mechanics (creating correctly-named branches, local merges of `bugfix/` into a `release/` branch). It cannot open or merge a PR for you. Tooling status changes over time, so check current documentation before relying on any helper.
 
+### Claude Code skill
+
+The repository also carries a Claude Code skill, **`educates-git-workflow`**, under [.claude/skills/educates-git-workflow](../.claude/skills/educates-git-workflow/). Anyone using Claude Code in a clone of this repository gets it automatically: asking for any of the operations described here or in the [release procedures](release-procedures.md) (starting a feature or bugfix branch, cutting or finishing a release, tagging, patching a support line, porting a fix across lines) will be driven through this workflow rather than improvised with raw git.
+
+What it does, and the guarantees it follows:
+
+* Runs pre-flight checks before proposing anything: clean working tree, no operation in progress, base branch up to date, and that the clone really is the canonical repo (or a fork, which restricts it to topic-branch operations).
+* Follows the naming conventions, enforces the tag-placement rule (rc only on `release/*`, alpha/beta only on `develop`), and checks release notes exist before a release or patch release can be finished.
+* States the exact commands with concrete version numbers and branch names, and waits for explicit confirmation before anything consequential: any push to a shared branch, any tag push, any branch deletion, any PR creation. Multi-step flows confirm each stage separately.
+* Only ever creates pull requests, never merges them, and does not bypass the rulesets.
+* Leaves the judgement calls to you: it asks about feature freeze, version numbers, whether to open a support line, and backport targets rather than deciding.
+
+This document and the release procedures remain **canonical**; the skill implements the flow described in them. A change to the strategy or procedures should be accompanied by a matching update to the skill, so the two do not drift.
+
 Features and Fixes for the Line Under Development
 -------------------------------------------------
 

--- a/developer-docs/branching-strategy.md
+++ b/developer-docs/branching-strategy.md
@@ -1,0 +1,129 @@
+Branching Strategy
+==================
+
+This project uses a branching strategy modelled on Gitflow, with some adaptations of its own. The arrangement below is described through a worked example in which `develop` is the integration line for the 4.x series while an earlier released line (3.x) is being patched.
+
+The version numbers here are **illustrative only**. They show how the branches relate; they are not a statement of the current versions, and this page is not necessarily kept in step with them as development moves on. Read `4.x`/`3.x` as "the line under development" and "an older released line", and apply the same patterns to whatever versions are current.
+
+This document covers the branching model itself and the day to day workflow for contributing features and fixes. The maintainer side, that is cutting releases, tagging versions, and opening and patching support lines, is covered in the [release procedures](release-procedures.md).
+
+Branch Overview
+---------------
+
+| Branch | Purpose | Branched from |
+|---|---|---|
+| `main` | Production-ready code; only **final** release tags live here | n/a |
+| `develop` | Integration line for the line under development (4.x in this example); alpha/beta tags are made here | `main` |
+| `support/<major>.<minor>.x` | Optional, on-demand maintenance line for a release line that needs patching; several can exist at once (e.g. `support/3.6.x`, `support/3.7.x`) | `main`, at that line's latest release tag, created only when a need to patch it arises |
+| `feature/4.0/*` | Individual features for the line under development | `develop` |
+| `release/<major>.<minor>.<patch>` | Stabilizing an imminent release; rc tags are made here (e.g. `release/4.0.0`) | `develop` |
+| `bugfix/<desc>` | A non-feature fix; for the in-development line, or for a release found broken during stabilization | `develop`, or the `release/` branch being stabilized |
+| `hotfix/<major>.<minor>.z` | A single fix for a maintained line | the matching `support/<major>.<minor>.x` |
+
+Repository Model: GitHub and Forks
+----------------------------------
+
+The canonical repository on GitHub is the source of truth. All shared, long-lived branches, meaning `main`, `develop`, and any `release/*` and `support/*` branches, live there. They are the team's coordination points; they are not recreated per-contributor.
+
+**Internal team: work directly in the canonical repo.** Members with write access push their own `feature/*` and `bugfix/*` branches straight to the canonical repo and open pull requests within it. There is no fork and no upstream/origin juggling: everyone fetches and pushes against the one repo. Branch protection on the shared branches (`main`, `develop`, `release/*`, `support/*`) enforces review and CI instead of a fork boundary. The exception is genuinely speculative work that should be kept out of the canonical repo, which can live in a personal fork until it is worth proposing.
+
+**Outside contributors: always fork.** People without write access fork the canonical repo, push their branch to their fork, and open a pull request from the fork back to the canonical repo, targeting the correct base branch (`develop`, or a `release/*` branch for a stabilization fix). A fork is a point-in-time snapshot: branches created on the canonical repo *after* the fork, including a new `release/*` branch, do not appear in the fork automatically. To work against one, add the canonical repo as the `upstream` remote, `git fetch upstream`, and branch from `upstream/<branch>`.
+
+`release/*` and `support/*` branches are shared infrastructure: they are created on the canonical repo by whoever runs releases, never independently in a contributor's fork. To contribute a stabilization fix without write access, branch off `upstream/release/...`, push the `bugfix/*` branch to your fork, and open a PR targeting the release branch on the canonical repo.
+
+GitHub Ruleset Constraints
+--------------------------
+
+The canonical repo is protected by GitHub rulesets, which impose constraints this model works within:
+
+* **Merges to `main`, `develop`, and `support/*` must go through pull requests.** A direct push to these branches is rejected, so every merge-back and release merge is a PR. This is why local "finish" style auto-push commands don't work against them.
+* **Published version tags are immutable.** The tag ruleset blocks updating or deleting tags matching the version pattern, so a release tag cannot be moved or removed once pushed. Tag creation is left open, so routine alpha/beta/rc tagging is unaffected.
+* **GitHub cannot enforce "rc tags only on `release/*`, alpha/beta only on `develop`".** A tag names a commit, not a branch, so no ruleset can tie a tag pattern to a branch. That rule is a **convention** upheld by process and, if desired, by a check in the CI workflow that inspects the tagged commit, not something GitHub enforces.
+
+Tooling
+-------
+
+This strategy is a branching *model* and does not depend on any particular tool. The **primary, recommended way to drive it is plain `git`** plus GitHub for pull requests. The recipes below and in the [release procedures](release-procedures.md) cover every branch/merge/tag step that way. This is deliberate: because merges to the shared branches must go through PRs, the steps that matter most are GitHub-side actions a local helper tool cannot perform anyway, so a helper buys relatively little here.
+
+A helper tool remains **optional**. If one is used, prefer **git-flow-next** (`git-flow.sh`). The classic `git-flow` (nvie) and `git-flow-avh` editions are both discontinued and the Homebrew `git-flow` formula is deprecated and scheduled to be disabled, whereas git-flow-next is the actively maintained successor and stays backward-compatible with the same `feature` / `release` / `hotfix` / `support` branch types. Note its value is limited in this setup: its "finish" automation merges and pushes locally, which the PR-requiring rulesets reject, so it helps mainly with the un-gated mechanics (creating correctly-named branches, local merges of `bugfix/` into a `release/` branch). It cannot open or merge a PR for you. Tooling status changes over time, so check current documentation before relying on any helper.
+
+Features and Fixes for the Line Under Development
+-------------------------------------------------
+
+All work for the line under development happens on `develop` as standard Gitflow.
+
+1. Branch a feature off `develop`: `feature/4.0/<short-description>`.
+2. Develop and review the feature.
+3. Merge back into `develop`.
+
+Use kebab-case for the description, kept short and descriptive, e.g. `feature/4.0/new-export-api`.
+
+A fix to the in-development line that isn't new functionality can use a `bugfix/<desc>` branch off `develop` instead of `feature/`; the workflow is otherwise identical (branch off `develop`, merge back into `develop`). The same `bugfix/` prefix is also used for fixes found while stabilizing a release, distinguished by which branch it is cut from.
+
+Documentation changes follow this same workflow: they land on `develop` through a normal `feature/*` or `bugfix/*` branch and PR, the same as code. There is no separate process for documentation updates between releases; the published documentation has a `latest` version built from `develop`, so documentation changes are publicly visible without waiting for a release (see the [release procedures](release-procedures.md) for details).
+
+Fixes During Release Stabilization
+----------------------------------
+
+Once a `release/*` branch exists (see the [release procedures](release-procedures.md) for when and how one is cut), changes to it are handled by where the change originates:
+
+* **A fix found during stabilization** (the normal case) is made on the `release/` branch. For small fixes, commit directly to the branch. For anything that warrants its own review or CI run, cut a `bugfix/<desc>` branch off `release/`, then merge it back. Either way the fix reaches `develop` later through the standard merge-back when the release is finished.
+* **A change that already exists on `develop`** (e.g. a fix made there first) is brought in by cherry-picking the specific commit(s) onto the `release/` branch.
+
+Do **not** merge `develop` into the `release/` branch to pull in a change. That drags all of develop's in-progress work into the release and defeats the freeze. Cherry-pick the individual commits instead.
+
+Maintenance of Released Lines
+-----------------------------
+
+A released line that needs patching after the fact gets an on-demand `support/<major>.<minor>.x` branch, cut from `main` at that line's latest release tag. Individual fixes for it are made on `hotfix/*` branches off the support branch, and patch releases are tagged on the support branch. A fix that affects more than one maintained line, security fixes in particular, must land on **all** affected lines that are still maintained, including `develop`.
+
+The mechanics of opening support lines, applying hotfixes, tagging patch releases, and propagating fixes across lines are maintainer operations covered in the [release procedures](release-procedures.md).
+
+Naming Conventions
+------------------
+
+* Lowercase, kebab-case descriptions: `feature/4.0/add-search-bar`.
+* Keep descriptions short but meaningful; a tracking issue number is optional.
+* Use the `/`-separated prefixes exactly as listed in the table above.
+
+Common Operations
+-----------------
+
+Recipes for the contributor-facing operations. `git` commands are the spine; where a pull request is needed, both a `gh` command and the web-UI alternative are shown. PRs are shown as *create only*, since review and merge happen after approval, in keeping with the ruleset's review requirement (do not auto-merge from the CLI). `gh` is the optional GitHub CLI (`brew install gh`, `gh auth login`); the web UI does the same job.
+
+If you have write access these recipes are run against a direct clone of the canonical repo, where `origin` is the canonical repo. If you are working from a fork, branch from the canonical repo's state (via the `upstream` remote), push the branch to your fork, and open the PR back to the canonical repo.
+
+### Start a feature or develop-line fix
+
+```
+git switch develop
+git pull
+git switch -c feature/4.0/new-export-api    # or bugfix/<desc> for a fix
+# ...work, commit...
+git push -u origin feature/4.0/new-export-api
+```
+
+Then open a PR into `develop`:
+
+```
+gh pr create --base develop --head feature/4.0/new-export-api --title "New export API"
+```
+
+or open it in the GitHub UI. After approval, merge the PR in the UI.
+
+### Contribute a fix to a release branch
+
+For a fix to a release being stabilized, base the branch on the `release/*` branch instead of `develop`, and target the PR at the release branch:
+
+```
+git switch release/4.0.0
+git pull
+git switch -c bugfix/some-fix
+# ...fix, commit...
+git push -u origin bugfix/some-fix
+gh pr create --base release/4.0.0 --head bugfix/some-fix --title "Fix ..."
+```
+
+From a fork, replace the first two commands with `git fetch upstream` and `git switch -c bugfix/some-fix upstream/release/4.0.0`.
+
+Release, tagging, and support-line operations are deliberately not listed here. They are maintainer actions performed on a direct clone of the canonical repo and are documented in the [release procedures](release-procedures.md).

--- a/developer-docs/release-procedures.md
+++ b/developer-docs/release-procedures.md
@@ -1,10 +1,16 @@
 Release Procedures
 ==================
 
-All changes pertaining to a new release should be worked on in forks of the main Educates GitHub repository, with changes submited via pull requests back to the `develop` branch of the main repository. When it is time for a release, the following steps should be followed.
+This document covers the maintainer side of the project's branch and release model: cutting release branches, tagging versions, finishing releases, and maintaining released lines. The branching model itself, and the workflow for contributing features and fixes, is described in the [branching strategy](branching-strategy.md). Read that first; this document assumes its terminology.
+
+All of the operations below are maintainer actions and are expected to be run from a **direct clone of the canonical repository**, where `origin` is the canonical repo. They should not be performed from a fork. The exceptions are the noted cases of testing the release process itself in a fork.
+
+The version numbers in the examples (`4.0.0`, `support/3.7.x`) are illustrative; substitute current versions.
 
 Updates to the Documentation
 ----------------------------
+
+Documentation changes follow the normal development workflow: they land on `develop` through `feature/*` or `bugfix/*` branches and pull requests, the same as code changes. The published documentation site provides a `latest` version built from the `develop` branch alongside the `stable` version built from the `main` branch, so documentation changes which have not yet shipped in a release are still publicly accessible from the `latest` version. There is no separate process for pushing documentation updates out between releases.
 
 Before any release is performed, documentation should first be updated for any changes being made in the release. Documentation updates should consist of:
 
@@ -14,20 +20,22 @@ Before any release is performed, documentation should first be updated for any c
 
 Where changes are non trivial or need further explanation, the release notes should include a cross reference to other parts of the documentation describing the feature.
 
+Once a `release/*` branch has been cut, release notes and documentation updates for that release count as stabilization work and are made on the `release/*` branch. They reach `develop` through the back-merge when the release is finished.
+
 Triggering a Development Build
 ------------------------------
 
-For any individual code changes the developer of the changes should have already built and tested the changes on their local system. If a complete build of Educates consisting of all code changes for a release is required, a build from the `develop` branch can be triggered using a GitHub actions workflow dispatch trigger event. This can be done from the GitHub actions page of the main Educates GitHub repository located at:
+For any individual code changes the developer of the changes should have already built and tested the changes on their local system. If a complete build of Educates consisting of all code changes for a release is required, a build can be triggered using a GitHub actions workflow dispatch trigger event. This can be done from the GitHub actions page of the main Educates GitHub repository located at:
 
 * [https://github.com/educates/educates-training-platform/actions](https://github.com/educates/educates-training-platform/actions)
 
 ![](github-actions-build.png)
 
-From the GitHub actions page select "Build and Publish Images" from the list of workflows, then click on the "Run workshop" dropdown. In the drop down select the branch `develop` and then the list of platforms to run the build.
+From the GitHub actions page select "Build and Publish Images" from the list of workflows, then click on the "Run workflow" dropdown. In the drop down select the branch to build and the list of platforms to run the build for. This will usually be the `develop` branch, but a build can equally be run from a `release/*` branch during stabilization, or a `support/*` branch when preparing a patch release.
 
 By default the build will only be run for the `linux/amd64` platform. The `linux/arm64` platform can instead be selected, or both, by selecting `linux/amd64,linux/arm64`. Note that any `linux/arm64` build will take significantly longer as the build is done under GitHub actions using the QEMU machine emulator and virtualizer.
 
-Being a development build, all the container images, client programs and package bundles will be created, but neither a package repository bundle or GitHub release will be created. To test the release, clients programs and package resource manifests for installing the development version can be downloaded from the build artifacts of the GitHub actions workflow run. Client programs can also be download by using the command:
+Being a development build, all the container images, client programs and package bundles will be created, but no GitHub release will be created. To test the build, client programs and package resource manifests for installing the development version can be downloaded from the build artifacts of the GitHub actions workflow run. For a build of the `develop` branch, client programs can also be downloaded by using the command:
 
 ```
 imgpkg pull -i ghcr.io/educates/educates-client-programs:develop -o /tmp/client-programs
@@ -35,63 +43,164 @@ imgpkg pull -i ghcr.io/educates/educates-client-programs:develop -o /tmp/client-
 
 A development build prior to a release would be done against the main Educates GitHub repository. If necessary a developer of some changes could also trigger such a build using GitHub actions from their fork of the Educates GitHub repository. In this case all container image references will resolve to images built and pushed to the developers GitHub container registry namespace and not that of the main Educates GitHub repository. For more complicated changes, it possibly should be a requirement that a developer do a full development build from their fork and test it before creating a pull request with their changes.
 
+Note that builds done in a fork will only include container images built for the `linux/amd64` platform by default, due to the significantly longer build times required for `linux/arm64`. If you need a build in a fork to include support for the `linux/arm64` platform, create a GitHub secret in the repository fork called `TARGET_PLATFORMS` with a value of `linux/arm64` or `linux/amd64,linux/arm64`.
+
 Tagged Pre-release Versions
 ---------------------------
 
-Development builds created by manually invoking the GitHub actions workflow are mutable and would be replaced by a subsequent development build. If you want to generate a more official pre-release version for testing (alpha, beta, or release candidate), you can create a tag in the Git repository against the corresponding commit in the `develop` branch and push the tag to GitHub. Pushing the tag will automatically trigger the GitHub action workflow to run. As with a development build all the container images, client programs and package bundles will be created. This time a GitHub release will be also be created but marked as pre-release. A package repository will still not be created however.
+Development builds created by manually invoking the GitHub actions workflow are mutable and would be replaced by a subsequent development build. To generate a more official pre-release version for testing, create a version tag against the appropriate commit and push the tag to GitHub. Pushing the tag will automatically trigger the GitHub actions workflow to run. As with a development build all the container images, client programs and package bundles will be created. This time a GitHub release will also be created, marked as pre-release.
 
-The format of the tags you can use for pre-release builds are:
+The format of the tags for pre-release builds are:
 
 * `X.Y.Z-alpha.N`
 * `X.Y.Z-beta.N`
 * `X.Y.Z-rc.N`
 
-These can be created against a branch of a fork created from the main GitHub repository, in which case the release will be added against the fork and not the main GitHub repository.
+The pre-release stages mark increasing maturity on the road to a final release, and which branch each is tagged on follows from the feature freeze line described below:
 
-Because the same tag might be used in the main GitHub repository, which would be propagated to the fork when the repositories are synchronized, use of these tags is discouraged in forks except for testing release procedures. If done for this purpose, it is suggest that a tag of the form `0.0.1-???.N` be used, and that after testing both the tag and GitHub release be deleted once no longer required, so that the same tag can be used again in such future testing.
+* **alpha** is early and unstable. Features for the release are still being added and may change or break; APIs are not settled. Alpha builds are for early testing of work in progress. Tagged on `develop`, before feature freeze.
+* **beta** is feature-complete (or nearly so) but not yet stabilized. The intended scope of the release is present and the focus shifts from adding features to finding and fixing bugs; breakage is still expected. Tagged on `develop`, still before feature freeze, but later in that window than alpha.
+* **rc** (release candidate) is believed ready to ship. The release is feature-frozen and on the `release/*` branch; only fixes for genuine release blockers go in. Each rc is a concrete candidate for the final release; if no blocker is found, that exact code becomes the release. Tagged on the `release/*` branch, after feature freeze.
 
-Note that pre-release versions created in a fork will only include container images built for the `linux/amd64` platform. If you need for a pre-release version created in a fork to include support for the `linux/arm64` platform, you will need to create a GitHub secret in the repository fork called `TARGET_PLATFORMS` with a value of `linux/arm64` or `linux/amd64,linux/arm64`. Only `linux/amd64` platform support is included by default when builds are done in a fork due to the significantly longer build times required for `linux/arm64`.
+Note that GitHub cannot enforce this placement (a tag names a commit, not a branch), so it is a convention upheld by process. Tags are not pushed automatically by anything; push them explicitly:
+
+```
+git switch release/4.0.0
+git tag 4.0.0-rc.1
+git push origin 4.0.0-rc.1
+```
+
+Once pushed to the canonical repo, a version tag is immutable. The tag ruleset blocks updates and deletions, so a tag cannot be moved or removed afterwards without bypass. If a pre-release build turns out to be broken, move on to the next pre-release number rather than attempting to re-tag.
+
+Version tags can also be created in a fork, in which case the GitHub release will be added against the fork and not the main GitHub repository. Because the same tag might be used in the main GitHub repository, which would be propagated to the fork when the repositories are synchronized, use of these tags is discouraged in forks except for testing release procedures. If done for this purpose, it is suggested that a tag of the form `0.0.1-???.N` be used, and that after testing both the tag and GitHub release be deleted from the fork once no longer required, so that the same tag can be used again in such future testing.
+
+Cutting a Release Branch
+------------------------
+
+A `release/*` branch isolates the stabilization of a version from ongoing development. It is named for the target version: `release/<major>.<minor>.<patch>` (e.g. `release/4.0.0`). It is not used during active development, only once a release is imminent.
+
+The dividing line is **feature freeze**: everything before it happens on `develop`, everything after it on the `release/*` branch. While features are still landing for the release, that work stays on `develop`, and alpha and beta tags are made there. At feature freeze, cut the `release/*` branch off `develop`:
+
+```
+git switch develop
+git pull
+git switch -c release/4.0.0
+git push -u origin release/4.0.0
+```
+
+From this point the release is frozen and no new features go onto it. On the `release/*` branch, do only stabilization work: bug fixes, version-number bumps, changelog and documentation updates. Tag rc builds here, since this branch holds the exact code being proposed for release.
+
+Cutting the branch at feature freeze lets the team start adding features to `develop` for the *next* version while this release is being finalized.
+
+Fixes During Stabilization
+--------------------------
+
+A small fix found during stabilization can be committed directly to the release branch:
+
+```
+git switch release/4.0.0
+# ...fix, commit...
+git push
+```
+
+A larger fix that warrants its own review or CI run goes on a `bugfix/*` branch off the release branch, merged back via a PR targeting the release branch:
+
+```
+git switch release/4.0.0
+git switch -c bugfix/some-fix
+# ...fix, commit...
+git push -u origin bugfix/some-fix
+gh pr create --base release/4.0.0 --head bugfix/some-fix --title "Fix ..."
+```
+
+To pull in a fix that already exists on `develop`, cherry-pick it. Do **not** merge `develop` into the release branch, as that drags all of develop's in-progress work into the release and defeats the freeze:
+
+```
+git switch release/4.0.0
+git cherry-pick <commit-sha>
+git push
+```
 
 Creating the Final Release
 --------------------------
 
-The use of a `develop` branch distinct from `main` was due to an original intention to follow a `gitflow` type model for branch management. With repository forks and pull requests in GitHub now being used as the means to manage contributions from distinct developers, the `gitflow` model is not now being strictly adhered to even though the `develop` branch has been retained.
+Because the shared branches are protected by GitHub rulesets that require pull requests, the merges that finish a release go through PRs, not a direct push. A local "merge and push" helper command (such as `git flow release finish`) does not work against these branches, because its push is a direct push the ruleset rejects.
 
-Although it is recommended a Git client supporting the `gitflow` model be used to manage the release, it is not strictly necessary. Either way, the outcome should be:
+```
+# 1. PR the release branch into main
+gh pr create --base main --head release/4.0.0 --title "Release 4.0.0"
+#    (or open in the UI) - review and merge the PR.
 
-* The `develop` branch should be merged into the `main` branch.
-* The merge commit should be tagged with the version for the final release.
-* The `main` branch at the point of the tagged version should be pulled back into the `develop` branch to align the two branches.
+# 2. Tag the final release on the merge commit on main
+git switch main
+git pull
+git tag 4.0.0
+git push origin 4.0.0
 
-The format of the tag you use for a final release should be:
+# 3. Back-merge main into develop so develop reflects what shipped
+git switch develop
+git pull
+git switch -c merge/4.0.0-to-develop
+git merge main          # resolve any conflicts, commit
+git push -u origin merge/4.0.0-to-develop
+gh pr create --base develop --head merge/4.0.0-to-develop --title "Back-merge 4.0.0 into develop"
+#    (or open in the UI) - review and merge the PR.
 
-* `X.Y.Z`
+# 4. Delete the finished release branch
+git push origin --delete release/4.0.0
+```
 
-Pushing the changes and tag back to GitHub should trigger the GitHub actions workflow for building the project and creating the release.
+The format of the tag for a final release is `X.Y.Z`, with no suffix. `main` only ever carries final release tags. Pushing the tag triggers the GitHub actions workflow, which will create all the container images, client programs and package bundles, and a GitHub release not marked as pre-release.
 
-The GitHub action in this case will result in the creation of all the container images, client programs and package bundles. A GitHub release will be also be created as well as a package repository bundle.
+The back-merge in step 3 ensures the release's stabilization fixes, and the release/version-bump commits, are not lost, and that `develop` reflects exactly what shipped. The release branch is ephemeral: once merged and tagged it has done its job, and the permanent record is the tag plus the merge commits, not the branch. Deleting it (step 4) is a deliberate, explicit step; keep it on the release checklist so stale `release/*` branches don't accumulate.
 
-Creation of a final release in a fork should only be done if testing the release process. In this case the version tag `0.0.1` should be used and the tag and GitHub release should be deleted once the test has been completed.
+As with pre-release tags, a pushed final release tag is immutable on the canonical repo and cannot be moved or removed. Creation of a final release in a fork should only be done if testing the release process. In this case the version tag `0.0.1` should be used and the tag and GitHub release should be deleted from the fork once the test has been completed.
 
-Merging Package Definitions
----------------------------
+Support Branches and Patch Releases
+-----------------------------------
 
-Upon a successful final release being created by the GitHub actions workflow, a pull request against the `develop` branch will be automatically created back against the GitHub repository. This pull request will contain the package resource definitions for the released version. This pull request should be merged prior to any subsequent release as the the package resource definitions need to exist in the repository so they can be included in the subsequent release. If this is not done then that version will be missing from subsequent versions of the package repository.
+A support branch is **not created by default**. One is cut only when there is an actual need to patch a released line, typically when development of the next `<major>.<minor>` will take a while and the current line needs fixes in the meantime. Until that need arises, no support branch exists for the line.
 
-In the case of creating a final release in a fork, this pull request will not be created. This is because the only source of package resource definitions should be from the GitHub actions workflow run from the main GitHub repository. Package resource definitions should never be added in a fork, nor merged from a fork to the main GitHub repository.
+When one is needed, cut it from `main` at that line's latest release tag, following the `support/<major>.<minor>.x` convention. More than one can be active at the same time when older versions still need patching, e.g. `support/3.6.x` for a user stuck on 3.6 alongside `support/3.7.x`.
 
-Adhoc Documentation Updates
----------------------------
+```
+git switch -c support/3.7.x 3.7.0     # branch from the last 3.7 release tag
+git push -u origin support/3.7.x
+```
 
-The public Educates documentation web site is updated from the `main` branch of the GitHub repository. Where documentation updates neatly fall within the time window for creating a final release, no special steps are required. Updating the public documentation outside of that time window gets more complicated because there may be in progress changes for both Educates code and documentation sitting within the `develop` branch which should not be merged into the `main` branch prior to a release.
+All fixes for a given line happen on its support branch, via a hotfix branch named for the next patch version. Merges to `support/*` branches must go through PRs, the same as `main` and `develop`:
 
-Until a better system is created for handling adhoc updates to the public documentation web site, the following is recommended.
+```
+git switch support/3.7.x
+git pull
+git switch -c hotfix/3.7.1
+# ...fix, commit...
+git push -u origin hotfix/3.7.1
+gh pr create --base support/3.7.x --head hotfix/3.7.1 --title "Fix ... (3.7.1)"
+#    (or open in the UI) - review and merge the PR.
+```
 
-1. Ensure that in your repository fork that the `main` branch is up to date with the main repository.
-2. When needing to make the documentation changes create the branch from the `main` branch instead of `develop`.
-3. Make the required changes in your documentation branch and push your branch to your repository fork.
-4. Create the pull request, ensure that it is being made relative to the `main` branch of the main repository and not `develop`.
-5. The pull request should then be merged to the `main` branch of the main repository.
-6. The `main` branch of the main repository should then be merged back into the `develop` branch.
+Then tag the patch release on the support branch and push the tag, which triggers the same release build as a final release:
 
-This process should only be used to make changes which affect the `project-docs` and `developer-docs` directories and which need to be made public in the `main` repository outside of the normal release schedule.
+```
+git switch support/3.7.x
+git pull
+git tag 3.7.1
+git push origin 3.7.1
+```
+
+When a maintained line reaches the end of its security-support window, retire its `support/*` branch. For each maintained line, the length of that window should be decided and documented when the line ships.
+
+Propagating Fixes Across Maintained Lines
+-----------------------------------------
+
+A vulnerability usually affects more than one line: several `support/*` branches and `develop`. Every fix must include a decision about which lines it applies to, and it must land on **all** affected lines that are still maintained.
+
+The default workflow is to apply the fix on the **oldest affected maintained line first**, then port it forward:
+
+* Fix on the oldest affected line, e.g. `support/3.6.x`.
+* Port forward into each newer maintained line in order (`support/3.7.x`), then into `develop`, by merge or cherry-pick. Cherry-pick is usually cleaner where the surrounding code has diverged.
+
+Working oldest-to-newest keeps the porting in one direction and avoids re-doing the fix. When a fix already exists on a newer line and an older maintained line turns out to be affected, back-port it by cherry-picking down to that older support branch.
+
+Treat "applied to every affected maintained line, including `develop`" as a required checklist item on every security fix, so a patched line never ships alongside another still-vulnerable one.

--- a/developer-docs/release-procedures.md
+++ b/developer-docs/release-procedures.md
@@ -5,6 +5,8 @@ This document covers the maintainer side of the project's branch and release mod
 
 All of the operations below are maintainer actions and are expected to be run from a **direct clone of the canonical repository**, where `origin` is the canonical repo. They should not be performed from a fork. The exceptions are the noted cases of testing the release process itself in a fork.
 
+If you use Claude Code, the `educates-git-workflow` skill shipped in this repository drives all of these operations with the project's checks and confirmation gates built in; see *Claude Code skill* under *Tooling* in the [branching strategy](branching-strategy.md).
+
 The version numbers in the examples (`4.0.0`, `support/3.7.x`) are illustrative; substitute current versions.
 
 Updates to the Documentation


### PR DESCRIPTION
Add new docs on updated git branching strategy for when working on Educates. Also includes a Claude skill for helping implement that strategy and handle releases.