### PR TITLE
Cross compile node-ca-injector instead of building non-native image under QEMU

### DIFF
--- a/node-ca-injector/Dockerfile
+++ b/node-ca-injector/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.10 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24.10 AS builder
 
 WORKDIR /src
 


### PR DESCRIPTION
The node-ca-injector Dockerfile already passed TARGETOS/TARGETARCH to "go build"
with CGO disabled, but the builder stage ran under each target platform, so in
a multi-arch build whichever platform didn't match the build host (arm64 when
building on amd64 GitHub runners, amd64 when building locally on an arm64
machine) executed the whole Go toolchain under QEMU emulation and was very
slow.

Pinning the builder stage to $BUILDPLATFORM makes the Go toolchain always run
natively on the build host and cross compile for the non-native target
architecture. As the final image is built from scratch with only a COPY, no
build step runs under emulation for either platform now.

Verified locally by pushing a multi-arch build to a local registry and
confirming the manifest list contains both linux/amd64 and linux/arm64 images.