### PR TITLE
Cross compile educates CLI image instead of building non-native image under QEMU

### DIFF
--- a/client-programs/Dockerfile
+++ b/client-programs/Dockerfile
@@ -2,10 +2,10 @@ ARG REPOSITORY=localhost:5001
 ARG TAG=latest
 
 # Add this stage before the builder stage
-FROM ${REPOSITORY}/educates-base-environment:${TAG} AS themes-source
+FROM --platform=$BUILDPLATFORM ${REPOSITORY}/educates-base-environment:${TAG} AS themes-source
 
 # Multi-stage build for client-programs
-FROM golang:1.25.0-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25.0-alpine AS builder
 
 # Install build dependencies
 RUN apk add --no-cache git ca-certificates tzdata
@@ -34,7 +34,7 @@ COPY --from=themes-source /opt/eduk8s/etc/themes pkg/renderer/files/
 ARG TARGETOS
 ARG TARGETARCH
 
-RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
     -o bin/educates-${TARGETOS}-${TARGETARCH} \
     cmd/educates/main.go
 


### PR DESCRIPTION
Applies the same treatment to the educates-cli image as was done for
node-ca-injector in #1050. The Dockerfile already passed TARGETOS/TARGETARCH to
"go build", but the builder stage ran under each target platform, so in a
multi-arch build whichever platform didn't match the build host executed the
whole Go toolchain (plus apk add and go mod download) under QEMU emulation and
was very slow.

Changes:

* Pin the builder stage to $BUILDPLATFORM so the Go toolchain always runs
  natively on the build host and cross compiles for the non-native target
  architecture.
* Pin the themes-source stage to $BUILDPLATFORM as well, since the theme files
  copied out of it are architecture independent. This avoids pulling the very
  large base-environment image once per target architecture.
* Add CGO_ENABLED=0 to "go build" so both architecture binaries are built
  identically (Go would otherwise only auto-disable CGO for the cross compiled
  architecture) and are fully static, as expected by the scratch final stage.

As the final image is built from scratch with only a COPY, no build step runs
under emulation for either platform now.

Verified locally with a multi-arch build using the Makefile target.