### PR TITLE
Fix lookup service workshop environment registration race and /auth/verify 500

### DIFF
--- a/lookup-service/service/handlers/clusters.py
+++ b/lookup-service/service/handlers/clusters.py
@@ -371,6 +371,7 @@ class ClusterOperator(GenericOperator):
                             generation=0,
                             labels=[],
                             url="",
+                            namespace="",
                             phase="Unknown",
                             credentials=PortalCredentials(
                                 client_id="",
@@ -547,6 +548,7 @@ class ClusterOperator(GenericOperator):
                             generation=0,
                             labels=[],
                             url="",
+                            namespace="",
                             phase="Unknown",
                             credentials=PortalCredentials(
                                 client_id="",

--- a/lookup-service/service/routes/authnz.py
+++ b/lookup-service/service/routes/authnz.py
@@ -222,6 +222,14 @@ async def api_auth_logout(request: web.Request) -> web.Response:
 
     return web.json_response({})
 
+
+async def api_auth_verify(request: web.Request) -> web.Response:
+    """Verify that the access token supplied is still valid. Reaching this
+    handler means the login_required wrapper already validated the token."""
+
+    return web.json_response({})
+
+
 # Set up the middleware and routes for the authentication and authorization.
 
 middlewares = [jwt_token_middleware]
@@ -230,5 +238,5 @@ routes = [
     web.post("/login", api_auth_login),
     web.post("/auth/login", api_auth_login),
     web.post("/auth/logout", api_auth_logout),
-    web.get("/auth/verify", login_required(lambda r: web.json_response({}))),
+    web.get("/auth/verify", login_required(api_auth_verify)),
 ]

--- a/project-docs/release-notes/version-3.7.2.md
+++ b/project-docs/release-notes/version-3.7.2.md
@@ -41,3 +41,11 @@ Bugs Fixed
 * Due to a race condition, if `exit` was run in the terminal to exit the shell,
   it would immediately reconnect when it was supposed to rely on a user to
   manually click on the reload button above.
+
+* Due to a race condition in the lookup service, introduced in version 3.7.1, if
+  a workshop environment was seen before the training portal hosting it had been
+  registered, an internal error would prevent that workshop environment from
+  being registered. The affected workshops would then be missing from the list
+  of available workshops and requests for sessions against those workshops would
+  fail. Whether the problem occurred depended on timing of events when the
+  lookup service started and so could vary across restarts.

--- a/project-docs/release-notes/version-3.7.2.md
+++ b/project-docs/release-notes/version-3.7.2.md
@@ -49,3 +49,9 @@ Bugs Fixed
   of available workshops and requests for sessions against those workshops would
   fail. Whether the problem occurred depended on timing of events when the
   lookup service started and so could vary across restarts.
+
+* The lookup service `/auth/verify` endpoint, used to check whether an access
+  token is still valid, always returned an HTTP 500 error due to the request
+  handler not being implemented as an asynchronous function. It now correctly
+  returns an HTTP 200 response for a valid token and an HTTP 401 response for an
+  expired or invalid token.


### PR DESCRIPTION
Back-port to develop of the two lookup service fixes merged to `release/3.7.2` in #1056 (cherry-picked, same two commits as separate commits). The bugs are present on the 4.0 line as well, so they are brought to develop now rather than waiting for the 3.7.2 back-merge.

## Bug 1 — workshop environment registration race (introduced in 3.7.1)

When a workshop environment event was processed before the training portal hosting it had been registered, the "unknown portal" placeholder `TrainingPortal(...)` construction in `service/handlers/clusters.py` omitted the `namespace` argument that became required in 3.7.1 (commit c2cef5c0), raising `TypeError: missing 1 required positional argument: 'namespace'`. The `workshopenvironments_event` handler crashed and the workshop environment was never registered.

Effect: affected workshops missing from the workshops listing, and session requests for them failing with HTTP 503. Depends on watch event ordering at startup, so it varied across restarts.

Fix: pass `namespace=""` in both placeholder constructions, matching the existing placeholder convention; the real namespace is filled in when the portal's own event is processed.

Verified on a cluster: unfixed, repeated pod restarts registered 0/1/2 of 2 environments nondeterministically with crashes; fixed, 10/10 restarts registered both with zero crashes and session requests succeed. Reproduced on both 3.13 and 3.14 images — a timing bug, not version-specific.

## Bug 2 — `/auth/verify` always returned HTTP 500

The route was registered with a synchronous lambda, but the `login_required` wrapper awaits its handler; awaiting an already-constructed `Response` raised `TypeError: object Response can't be used in 'await' expression`.

Fix: replace the lambda with a proper `async def api_auth_verify` handler.

Verified on a cluster: valid token returns 200 (was 500), invalid token 401, missing header 400.