### PR TITLE
Update image-cache base image to Fedora 44

### DIFF
--- a/image-cache/Dockerfile
+++ b/image-cache/Dockerfile
@@ -1,6 +1,6 @@
 #syntax=docker/dockerfile:1.3-labs
 
-FROM fedora:42
+FROM fedora:44
 
 ARG TARGETARCH
 


### PR DESCRIPTION
Bumps the image-cache base image from `fedora:42` to `fedora:44`, aligning it with the other Fedora-based images. The base layers are shared with the workshop base environment image, so this carries little additional cost.

The bundled zot OCI registry stays pinned at **1.4.3**: it is the last stable 1.x release (the next stable release was 2.0.0, which changes the configuration shape), so there is no 1.x update to take and the existing zot config is unaffected.

No other changes — the zot download, checksum verification, entrypoint, and command are unchanged.

## Verification

- Builds cleanly for both `linux/amd64` and `linux/arm64` (confirming `curl`/`sha256sum` are present on fedora:44 and the zot download + checksum verification still pass).
- zot runs in the rebuilt image (`zot serve --help`).