### PR TITLE
Upgrade django-csp to 4.0 in training-portal

### DIFF
--- a/training-portal/pyproject.toml
+++ b/training-portal/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "django-oauth-toolkit==2.3.0",
     "django-cors-headers==4.9.0",
     "requests>=2.33.0",
-    "django-csp==3.7",
+    "django-csp==4.0",
     "kopf[full-auth]>=1.44.6",
     "pykube-ng>=23.6.0",
     "rstr>=3.2.2",

--- a/training-portal/src/project/apps/workshops/views/session.py
+++ b/training-portal/src/project/apps/workshops/views/session.py
@@ -117,8 +117,10 @@ def session(request, name):
     # of the users session.
 
     return csp_update(
-        CONNECT_SRC=f"{instance.name}.{settings.INGRESS_DOMAIN}",
-        FRAME_SRC=f"{instance.name}.{settings.INGRESS_DOMAIN}",
+        {
+            "connect-src": [f"{instance.name}.{settings.INGRESS_DOMAIN}"],
+            "frame-src": [f"{instance.name}.{settings.INGRESS_DOMAIN}"],
+        }
     )(lambda: response)()
 
 

--- a/training-portal/src/project/settings.py
+++ b/training-portal/src/project/settings.py
@@ -1,5 +1,6 @@
 import os
 
+from csp.constants import NONCE, NONE, SELF
 from django.core.management.utils import get_random_secret_key
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -229,35 +230,37 @@ THEME_NAME = os.environ.get("THEME_NAME", "")
 
 CORS_ALLOW_ALL_ORIGINS = True
 
-CSP_CONNECT_SRC = (
-    "'self'",
-    f"*.{INGRESS_DOMAIN}",
-    "*.google-analytics.com",
-    "*.clarity.ms",
-    "c.bing.com",
-    "*.amplitude.com",
-)
-
-CSP_DEFAULT_SRC = ("'none'",)
-CSP_STYLE_SRC = ("'self'",)
-CSP_SCRIPT_SRC = ("'self'", "www.clarity.ms", "cdn.amplitude.com")
-CSP_IMG_SRC = (
-    "'self'",
-    "data:",
-    "*.google-analytics.com",
-    "*.googletagmanager.com",
-)
-CSP_FONT_SRC = ("'self'",)
-CSP_FRAME_SRC = ("'self'",)
-CSP_INCLUDE_NONCE_IN = ("script-src",)
-CSP_FRAME_ANCESTORS = ("'self'",)
+CONTENT_SECURITY_POLICY = {
+    "DIRECTIVES": {
+        "default-src": [NONE],
+        "script-src": [SELF, "www.clarity.ms", "cdn.amplitude.com", NONCE],
+        "style-src": [SELF],
+        "img-src": [
+            SELF,
+            "data:",
+            "*.google-analytics.com",
+            "*.googletagmanager.com",
+        ],
+        "font-src": [SELF],
+        "connect-src": [
+            SELF,
+            f"*.{INGRESS_DOMAIN}",
+            "*.google-analytics.com",
+            "*.clarity.ms",
+            "c.bing.com",
+            "*.amplitude.com",
+        ],
+        "frame-src": [SELF],
+        "frame-ancestors": [SELF],
+    }
+}
 
 CSRF_TRUSTED_ORIGINS = [f"{INGRESS_PROTOCOL}://{PORTAL_HOSTNAME}"]
 
 FRAME_ANCESTORS = os.environ.get("FRAME_ANCESTORS", "")
 
 if FRAME_ANCESTORS:
-    CSP_FRAME_ANCESTORS = FRAME_ANCESTORS.split(",")
+    CONTENT_SECURITY_POLICY["DIRECTIVES"]["frame-ancestors"] = FRAME_ANCESTORS.split(",")
     SESSION_COOKIE_SAMESITE = "None"
     SESSION_COOKIE_SECURE = True
     CSRF_COOKIE_SAMESITE = "None"

--- a/training-portal/uv.lock
+++ b/training-portal/uv.lock
@@ -281,14 +281,15 @@ wheels = [
 
 [[package]]
 name = "django-csp"
-version = "3.7"
+version = "4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django" },
+    { name = "packaging" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/04/76/bdb879b0e73798a8f5d568d19e77995c0319b82ddfa6c2fee4d15e956e1a/django_csp-3.7.tar.gz", hash = "sha256:01eda02ad3f10261c74131cdc0b5a6a62b7c7ad4fd017fbefb7a14776e0a9727", size = 12821, upload-time = "2020-08-12T18:50:35.687Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/db/23567744dff2169aadb095f726088074476b24dfff5a759ffcf6389cf401/django_csp-4.0.tar.gz", hash = "sha256:b27010bb702eb20a3dad329178df2b61a2b82d338b70fbdc13c3a3bd28712833", size = 20028, upload-time = "2025-04-02T16:41:46.721Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/04/1e3b703e584fef3522065415d9b2f7550d8996d7e590d9b70b8c480ecc69/django_csp-3.7-py2.py3-none-any.whl", hash = "sha256:01443a07723f9a479d498bd7bb63571aaa771e690f64bde515db6cdb76e8041a", size = 17390, upload-time = "2020-08-12T18:50:34.713Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/a4/736ab90ee527a23e194d1ce7358c6bcced66381ced83c28268b4aea236f7/django_csp-4.0-py3-none-any.whl", hash = "sha256:d5a0a05463a6b75a4f1fc1828c58c89af8db9364d09fc6e12f122b4d7f3d00dc", size = 25689, upload-time = "2025-04-02T16:41:45.689Z" },
 ]
 
 [[package]]
@@ -766,7 +767,7 @@ requires-dist = [
     { name = "django", specifier = "==4.2.30" },
     { name = "django-cors-headers", specifier = "==4.9.0" },
     { name = "django-crispy-forms", specifier = "==2.5" },
-    { name = "django-csp", specifier = "==3.7" },
+    { name = "django-csp", specifier = "==4.0" },
     { name = "django-oauth-toolkit", specifier = "==2.3.0" },
     { name = "django-registration", specifier = "==3.4" },
     { name = "kopf", extras = ["full-auth"], specifier = ">=1.44.6" },


### PR DESCRIPTION
Upgrades django-csp from 3.7 to 4.0 in the training-portal. django-csp 4.0 still officially supports Django 4.2 LTS, so this is independent of the larger Django version upgrade — it is landed on its own ahead of the more involved add-on upgrades (django-registration, django-oauth-toolkit) that are tied to moving to Django 5.2.

## Changes

- **Settings** ([settings.py](../blob/develop/training-portal/src/project/settings.py)): the individual `CSP_*` settings are replaced by django-csp 4.0's single `CONTENT_SECURITY_POLICY = {"DIRECTIVES": {...}}` dict. The script-src nonce moves from `CSP_INCLUDE_NONCE_IN` to the `csp.constants.NONCE` sentinel placed in the directive's source list, and the `FRAME_ANCESTORS` environment override now mutates the directives dict. Middleware path (`csp.middleware.CSPMiddleware`) and the `{{ request.csp_nonce }}` templates are unchanged.
- **Session view** ([session.py](../blob/develop/training-portal/src/project/apps/workshops/views/session.py)): the dynamic per-session `connect-src`/`frame-src` additions are updated for the new `csp_update` decorator signature, which now takes a single dict keyed by directive name instead of upper-case keyword arguments.
- **Dependency**: `django-csp` 3.7 → 4.0 (`pyproject.toml` / `uv.lock`).

## Validation

The emitted `Content-Security-Policy` header is unchanged, verified directive-for-directive against the previous deployment on static/auth/admin pages. The per-request nonce behaviour is preserved: it is absent on pages that do not render it (login, admin) and present in `script-src` on the workshop session page, whose inline readiness-check script depends on it. The workshop session page was confirmed loading and becoming ready in a live cluster, exercising both the dynamic `csp_update` append and the nonce path.