### PR TITLE
Upgrade django-registration to 5.2.1 in training-portal

### DIFF
--- a/training-portal/pyproject.toml
+++ b/training-portal/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.13,<3.14"
 dependencies = [
     "mod_wsgi==6.0.4",
     "Django==4.2.30",
-    "django-registration==3.4",
+    "django-registration==5.2.1",
     "django-crispy-forms==2.5",
     "crispy-bootstrap5==2025.6",
     "wrapt>=2.2.1",

--- a/training-portal/uv.lock
+++ b/training-portal/uv.lock
@@ -309,15 +309,15 @@ wheels = [
 
 [[package]]
 name = "django-registration"
-version = "3.4"
+version = "5.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "confusable-homoglyphs" },
     { name = "django" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/71/00/ee3e5e08cb16475836f9ad117631f598f62a4e32a37c01ab4cb0859454ea/django-registration-3.4.tar.gz", hash = "sha256:1a0ccef7ef71e67a78a551abd8ad378977dc14a036f1fcd8be422a68bd5254a9", size = 89040, upload-time = "2023-07-04T01:25:38.448Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/a0/f6e6d0a59b94eb4ab14983853334cb25401d677c5a3799aaca6819acf2eb/django_registration-5.2.1.tar.gz", hash = "sha256:06864f9da0bc4d7b073fb2da98d95d12428357ab0bc46e33f79c26707ec06bbe", size = 94187, upload-time = "2025-04-07T05:54:48.558Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/06/3a/455455a208cd38c7fececec136e0de4a848004a7dafe4d62e55566dcbbfe/django_registration-3.4-py3-none-any.whl", hash = "sha256:fa76df481189794f47eb73043ee5cc9bfb0963194b901d7bd8cf914beab1ddd0", size = 96588, upload-time = "2023-07-04T01:25:36.714Z" },
+    { url = "https://files.pythonhosted.org/packages/78/5d/aa2f82b3c809db66eb986963db1d4b89de190b4eac2e3021a725112e3b13/django_registration-5.2.1-py3-none-any.whl", hash = "sha256:7079e2364b15fc6bef18b81ae94c5e947b556abdbbfb19c9bcca14feafde6a3d", size = 105277, upload-time = "2025-04-07T05:54:46.981Z" },
 ]
 
 [[package]]
@@ -769,7 +769,7 @@ requires-dist = [
     { name = "django-crispy-forms", specifier = "==2.5" },
     { name = "django-csp", specifier = "==4.0" },
     { name = "django-oauth-toolkit", specifier = "==2.3.0" },
-    { name = "django-registration", specifier = "==3.4" },
+    { name = "django-registration", specifier = "==5.2.1" },
     { name = "kopf", extras = ["full-auth"], specifier = ">=1.44.6" },
     { name = "mod-wsgi", specifier = "==6.0.4" },
     { name = "pykube-ng", specifier = ">=23.6.0" },


### PR DESCRIPTION
Upgrades django-registration from 3.4 to 5.2.1 in the training-portal. django-registration 5.2.1 still officially supports Django 4.2 LTS, so this is independent of the larger Django version upgrade and is landed on its own.

## Background

There is no django-registration 4.x series. The project adopted "DjangoVer" versioning and jumped from 3.4 straight to 5.1.0, aligning the version's major.minor with the latest supported Django feature release. Both 5.x releases still support Django 4.2 (they bundle a backport of Django 5.1's `SetPasswordMixin` for older Django versions), and require Python >= 3.9 (the image runs 3.13).

## Why no source changes are needed

- The portal uses the **one-step** registration backend (`django_registration.backends.one_step.urls`), whose import path and behaviour are unchanged in 5.x.
- **Anonymous** access (`REGISTRATION_TYPE=anonymous`, the mode most deployments use) does not go through django-registration at all — it creates users directly via Django auth and logs them in.
- The 5.x `RegistrationForm` rewrite (no longer a `UserCreationForm` subclass) is absorbed by the overridden `registration_form.html`, which renders the form via crispy-forms rather than referencing individual fields.
- The headline 5.x breaking change — the `ActivationView` rewrite (GET to POST plus activation template changes) — only affects the two-step activation workflow, which Educates does not use.

## Validation

End-to-end one-step registration was exercised against the rebuilt image: the register page renders, submitting the form creates the account and logs the user in immediately (redirect to the completion page), and the closed-registration path redirects to the closed page. `manage.py check` reports no issues and Django remains pinned at 4.2.30. Both one-step and anonymous registration were confirmed working in a live cluster.