### PR TITLE
Upgrade django-oauth-toolkit to 3.3.0 in training-portal

### DIFF
--- a/training-portal/pyproject.toml
+++ b/training-portal/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "django-crispy-forms==2.5",
     "crispy-bootstrap5==2025.6",
     "wrapt>=2.2.1",
-    "django-oauth-toolkit==2.3.0",
+    "django-oauth-toolkit==3.3.0",
     "django-cors-headers==4.9.0",
     "requests>=2.33.0",
     "django-csp==4.0",

--- a/training-portal/uv.lock
+++ b/training-portal/uv.lock
@@ -294,7 +294,7 @@ wheels = [
 
 [[package]]
 name = "django-oauth-toolkit"
-version = "2.3.0"
+version = "3.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django" },
@@ -302,9 +302,9 @@ dependencies = [
     { name = "oauthlib" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/22/2b/e0353101e242f1fb4e90a9bc5aa43894afd73e2e4650f40c6579e8f39389/django-oauth-toolkit-2.3.0.tar.gz", hash = "sha256:cf1cb1a5744672e6bd7d66b4a110a463bcef9cf5ed4f27e29682cc6a4d0df1ed", size = 89737, upload-time = "2023-05-31T21:04:46.768Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/2b/011f3e964f474b7814828586de0277ad373197096b28274d0ae8bf45d5f9/django_oauth_toolkit-3.3.0.tar.gz", hash = "sha256:2b375d14b1c0ff86e5df5e5de5d1a6d9868873304f54aca37c50158552d5b922", size = 118319, upload-time = "2026-05-29T18:13:57.065Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/d7/0cbac32a14981d96e951c0fe76a113c4d415db2b093bdfdbbbbeea9df0e6/django_oauth_toolkit-2.3.0-py3-none-any.whl", hash = "sha256:47dfeab97ec21496f307c2cf3468e64ca08897fa499bf3104366d32005c9111d", size = 68890, upload-time = "2023-05-31T21:05:34.805Z" },
+    { url = "https://files.pythonhosted.org/packages/26/e4/d05b3d50d0250f2d2f3a5dc9cd21f85e313ee1493ff60b729dccb8e08c46/django_oauth_toolkit-3.3.0-py3-none-any.whl", hash = "sha256:7af1365cd80735211454b0dca810bc9e860c631e61fd17768ad0fa331737954f", size = 88415, upload-time = "2026-05-29T18:13:55.827Z" },
 ]
 
 [[package]]
@@ -768,7 +768,7 @@ requires-dist = [
     { name = "django-cors-headers", specifier = "==4.9.0" },
     { name = "django-crispy-forms", specifier = "==2.5" },
     { name = "django-csp", specifier = "==4.0" },
-    { name = "django-oauth-toolkit", specifier = "==2.3.0" },
+    { name = "django-oauth-toolkit", specifier = "==3.3.0" },
     { name = "django-registration", specifier = "==5.2.1" },
     { name = "kopf", extras = ["full-auth"], specifier = ">=1.44.6" },
     { name = "mod-wsgi", specifier = "==6.0.4" },


### PR DESCRIPTION
Upgrades django-oauth-toolkit from 2.3.0 to 3.3.0 in the training-portal. 3.3.0 still officially supports Django 4.2 LTS (and adds Python 3.13/3.14 support), so this lands on its own, independent of the larger Django version upgrade. This is the last of the deferred Django add-on upgrades.

## Why no source changes are needed

The portal acts as the OAuth2 provider and uses the **built-in** `oauth2_provider.Application` model (not a swapped custom model). Every DOT API it depends on is unchanged in 3.3.0:

- the `AuthorizationView` / `TokenView` / `RevokeTokenView` endpoints
- the `protected_resource` decorator (catalog / user / environment / session views)
- `OAuth2TokenMiddleware` and the `OAuth2Backend` authentication backend
- `clear_expired`, and the `OAUTH2_PROVIDER` settings keys in use (`SCOPES`, token expiry, `PKCE_REQUIRED`)

Client-secret hashing is not new — 2.3.0 already hashes via `ClientSecretField`, and 3.3.0 keeps that (`hash_client_secret` defaults true) — so the application create/lookup patterns for the robot (password grant) and per-session (authorization-code grant) clients behave identically, and persisted records stay valid across the in-place migration.

## Database migrations

No `makemigrations` is required — because the built-in application model is used, DOT ships its own migrations. It adds **0008–0014** (additive fields plus a data migration in 0012 that recomputes a new `token_checksum` for existing access tokens), which are applied by the `manage.py migrate` step already run on startup. The portal database is on a PVC tied to the deployment, so this runs in place over existing data; existing applications, tokens and users are preserved.

## Schemes / http deployments

Redirect-URI scheme validation continues to use `ALLOWED_REDIRECT_URI_SCHEMES`, whose default `["http", "https"]` is unchanged, so http-only deployments (including in-cluster direct-to-service authorization over http) are unaffected. The new `ALLOWED_SCHEMES` default `["https"]` only governs DOT's native CORS `allowed_origins` feature, which the portal does not use, so no settings change is needed. `PKCE_REQUIRED` remains explicitly false.

## Validation

Image builds with Django pinned at 4.2.30; migrations 0008–0014 apply cleanly; `manage.py check` reports no issues; the OAuth-using modules import; robot (password) and per-session (authorization-code, with an http redirect URI) application records create correctly with hashed secrets and pass redirect-scheme validation. The OAuth flows for a workshop session were confirmed working in a live cluster.