### PR TITLE
Add a terminal workshop session finished page for the training portal

### DIFF
--- a/client-programs/pkg/educatesrestapi/catalog.go
+++ b/client-programs/pkg/educatesrestapi/catalog.go
@@ -229,7 +229,7 @@ func (c *WorkshopsCatalogRequester) RequestWorkshop(workshopName string, environ
 	}
 
 	if indexUrl == "" {
-		indexUrl = fmt.Sprintf("%s/accounts/logout/", c.PortalUrl)
+		indexUrl = fmt.Sprintf("%s/workshops/finished/", c.PortalUrl)
 	}
 
 	queryString := url.Values{}

--- a/training-portal/src/project/apps/workshops/templates/workshops/finished.html
+++ b/training-portal/src/project/apps/workshops/templates/workshops/finished.html
@@ -1,0 +1,21 @@
+{% extends "project-base.html" %}
+
+{% block content %}
+  <div class="jumbotron jumbotron-fluid">
+    <div class="container">
+      <div class="finished">
+        {% if notification == "session-unavailable" %}
+        <h1>Workshop session unavailable</h1>
+        <p>A workshop session could not be allocated. You have been signed out.</p>
+        {% elif notification == "workshop-invalid" %}
+        <h1>Workshop not available</h1>
+        <p>The requested workshop is not available. You have been signed out.</p>
+        {% else %}
+        <h1>Workshop session finished</h1>
+        <p>Your workshop session has ended. You have been signed out.</p>
+        {% endif %}
+        <p>You may now close this browser window.</p>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/training-portal/src/project/apps/workshops/urls.py
+++ b/training-portal/src/project/apps/workshops/urls.py
@@ -4,6 +4,7 @@ from . import views
 
 urlpatterns = [
     path("access/", views.access, name="workshops_access"),
+    path("finished/", views.finished, name="workshops_finished"),
     path("catalog/", views.catalog, name="workshops_catalog"),
     path(
         "catalog/environments/",

--- a/training-portal/src/project/apps/workshops/views/__init__.py
+++ b/training-portal/src/project/apps/workshops/views/__init__.py
@@ -5,5 +5,6 @@
 from .access import *
 from .environment import *
 from .catalog import *
+from .finished import *
 from .session import *
 from .user import *

--- a/training-portal/src/project/apps/workshops/views/finished.py
+++ b/training-portal/src/project/apps/workshops/views/finished.py
@@ -1,0 +1,28 @@
+"""Defines the view handler for the terminal page shown when a workshop session
+has finished.
+
+"""
+
+__all__ = ["finished"]
+
+from django.shortcuts import render
+from django.views.decorators.http import require_http_methods
+from django.contrib.auth import logout
+
+
+@require_http_methods(["GET"])
+def finished(request):
+    """Terminal page reached when a workshop session has finished. Signs out the
+    current user so that an anonymous user created for a workshop session is not
+    inherited by a subsequent visit to the training portal, then renders a
+    message indicating the session is over. This is intentionally a dead end and
+    provides no link back into the portal.
+
+    """
+
+    if request.user.is_authenticated:
+        logout(request)
+
+    notification = request.GET.get("notification", "session-deleted").strip()
+
+    return render(request, "workshops/finished.html", {"notification": notification})

--- a/training-portal/src/project/static/styles/project.css
+++ b/training-portal/src/project/static/styles/project.css
@@ -31,3 +31,8 @@
   padding-top: 15px;
   padding-bottom: 15px;
 }
+
+.finished {
+  padding-top: 15px;
+  padding-bottom: 15px;
+}


### PR DESCRIPTION
Adds a dedicated `/workshops/finished/` page used as the session index URL for sessions requested via `educates cluster workshop request`, replacing the previous reuse of the account logout URL as the default index URL.

## Why

When a session is requested through `educates cluster workshop request` without an explicit `--index-url`, the CLI previously defaulted the session index URL to `<portal>/accounts/logout/`, and the portal redirects (GET) to that index URL when the session ends. That relies on the auth logout view being reachable via GET, which is being removed in newer Django. Rather than re-enable GET on the generic auth logout, this adds a purpose-built terminal page.

This path is **only** exercised by the CLI workshop request mechanism. The web interface "Start workshop" flow does not set a session index URL, so it never redirects to this page.

## Changes

Training portal:
- New `workshops_finished` view at `/workshops/finished/` (GET) that signs out the current user — so an anonymous user created for the session is not inherited by a later visit to the portal — and renders a terminal "session finished" message with no link back into the portal. The message is selected from the existing `notification` query parameter.
- `finished.html` template, wrapped to match the top spacing of the other portal pages (`.finished` rule alongside `.login`/`.register`).

CLI:
- `educates cluster workshop request` now defaults the session index URL to `<portal>/workshops/finished/` instead of `<portal>/accounts/logout/`.

No compatibility shim is provided for old CLI versions against a portal built from this change; the CLI and portal are treated as version-matched.

## Validation

Built and exercised the page: GET signs the user out (verified the session is cleared), renders the finished message with no sign-in link, returns 405 on POST (GET-only by design), and serves anonymously. The CLI change compiles. End-to-end exit-of-a-CLI-requested-session was confirmed in a live cluster.