### PR TITLE
Upgrade training portal from Django 4.2 LTS to Django 5.2 LTS

### DIFF
--- a/training-portal/pyproject.toml
+++ b/training-portal/pyproject.toml
@@ -5,7 +5,7 @@ description = "Training portal for the Educates training platform."
 requires-python = ">=3.13,<3.14"
 dependencies = [
     "mod_wsgi==6.0.4",
-    "Django==4.2.30",
+    "Django==5.2.15",
     "django-registration==5.2.1",
     "django-crispy-forms==2.5",
     "crispy-bootstrap5==2025.6",

--- a/training-portal/src/project/settings.py
+++ b/training-portal/src/project/settings.py
@@ -115,8 +115,6 @@ TIME_ZONE = "UTC"
 
 USE_I18N = True
 
-USE_L10N = True
-
 USE_TZ = True
 
 

--- a/training-portal/uv.lock
+++ b/training-portal/uv.lock
@@ -242,16 +242,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "4.2.30"
+version = "5.2.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/11/b5/f1a53dc68da6429d6e0345bb848161e2381a2e9f02700148911e8582c2b3/django-4.2.30.tar.gz", hash = "sha256:4ebc7a434e3819db6cf4b399fb5b3f536310a30e8486f08b66886840be84b37c", size = 10468707, upload-time = "2026-04-07T14:05:45.57Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/e3/31722f7284c9f43333daff9aee9184678e4487adcb5506af0db8cea09ce1/django-5.2.15.tar.gz", hash = "sha256:5154a9bf84ac01dde011e367f355c07dbb329532e06810dcf3ef2af269e236e7", size = 10873669, upload-time = "2026-06-03T13:03:35.892Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/b7/a7c96f239cf91313a6589233fed55111c7063b26683b226802732c455dbc/django-4.2.30-py3-none-any.whl", hash = "sha256:4d07aaf1c62f9984842b67c2874ebbf7056a17be253860299b93ae1881faad65", size = 7997231, upload-time = "2026-04-07T14:05:38.241Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/38140b1643c00d5c46ce69c78e6980fd285aee223100319631bedee4f5e7/django-5.2.15-py3-none-any.whl", hash = "sha256:0eb4a9bb1853a35b0286dbc6d916bd352c8c2687195a7f2d6f80cefd840e4970", size = 8311957, upload-time = "2026-06-03T13:03:31.329Z" },
 ]
 
 [[package]]
@@ -764,7 +764,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "crispy-bootstrap5", specifier = "==2025.6" },
-    { name = "django", specifier = "==4.2.30" },
+    { name = "django", specifier = "==5.2.15" },
     { name = "django-cors-headers", specifier = "==4.9.0" },
     { name = "django-crispy-forms", specifier = "==2.5" },
     { name = "django-csp", specifier = "==4.0" },


### PR DESCRIPTION
Moves the training portal from Django 4.2 LTS to the current Django 5.2 LTS line. Django 4.2 LTS reaches end of extended support in April 2026.

## Changes
- \`Django==4.2.30\` → \`Django==5.2.15\` in pyproject.toml, with uv.lock re-locked (only Django changed; asgiref/sqlparse already satisfied 5.2's requirements).
- Removed \`USE_L10N = True\` from settings.py — the setting was removed in Django 5.0 (localized formatting is now always enabled). \`USE_TZ = True\` already matches the 5.x default.

## Context
All django-* add-ons were already moved to Django 5.x-compatible versions in prior PRs (django-csp 4.0 #1063, django-registration 5.2.1 #1065, django-oauth-toolkit 3.3.0 #1066), so this is the final dependency that needed bumping. The GET-logout 405 regression introduced by Django 5.0's POST-only LogoutView was pre-resolved by the terminal \`/workshops/finished/\` page (#1067), so no logout changes are needed here.

## Verification
- \`uv sync --frozen\` resolves cleanly to Django 5.2.15.
- \`manage.py makemigrations --check --dry-run\` reports no changes — no portal-model migrations are generated. Django's bundled contrib migrations apply in place against the PVC-backed database on startup.
- \`manage.py check\` reports no issues.
- Basic portal UI flow verified in-cluster.