### PR TITLE
Redirect expired sessions at workshop session end to finished page

### DIFF
--- a/project-docs/release-notes/version-4.0.0.md
+++ b/project-docs/release-notes/version-4.0.0.md
@@ -39,6 +39,15 @@ Features Changed
   without a slash after the short code, they will need to be updated to use the
   documented form.
 
+* If a user ends a workshop session, or attempts to return to one, after their
+  training portal login session has already expired, for example after leaving
+  the browser window open for a long period after the workshop session had
+  finished, they are now shown the workshop session finished page rather than
+  being redirected to the portal login page. Previously an expired login in
+  this situation could result in the portal login page being displayed, which
+  was undesirable when workshop sessions are coordinated by a custom front end
+  through the training portal REST API.
+
 Bugs Fixed
 ----------
 

--- a/training-portal/src/project/apps/workshops/templates/workshops/finished.html
+++ b/training-portal/src/project/apps/workshops/templates/workshops/finished.html
@@ -10,6 +10,9 @@
         {% elif notification == "workshop-invalid" %}
         <h1>Workshop not available</h1>
         <p>The requested workshop is not available. You have been signed out.</p>
+        {% elif notification == "session-expired" %}
+        <h1>Workshop session expired</h1>
+        <p>Your workshop session is no longer available and you have been signed out.</p>
         {% else %}
         <h1>Workshop session finished</h1>
         <p>Your workshop session has ended. You have been signed out.</p>

--- a/training-portal/src/project/apps/workshops/views/session.py
+++ b/training-portal/src/project/apps/workshops/views/session.py
@@ -44,7 +44,7 @@ from ..models import TrainingPortal, SessionState
 from .helpers import update_query_params
 
 
-@login_required(login_url="/")
+@login_required(login_url="/workshops/finished/?notification=session-expired")
 @require_http_methods(["GET"])
 @resources_lock
 @transaction.atomic
@@ -226,7 +226,7 @@ def session_terminate(request, name):
     return JsonResponse(details)
 
 
-@login_required(login_url="/")
+@login_required(login_url="/workshops/finished/?notification=session-expired")
 @require_http_methods(["GET"])
 @resources_lock
 @transaction.atomic


### PR DESCRIPTION
## Problem

When a user ends a workshop session (or returns to one) after their training portal login session has expired — e.g. leaving the browser window open for a long period after the workshop has finished — the \`@login_required(login_url="/")\` decorator on the \`session\` and \`session_delete\` views redirects them to the portal index. For a private-catalog deployment the index then redirects to the **portal login page**.

This is undesirable when workshop sessions are coordinated by a custom front end through the training portal REST API, because it exposes the portal login page. The \`index_url\` redirect logic in the handler body never runs in this case — the \`login_required\` decorator short-circuits first, since the request is no longer authenticated.

## Change

Point the \`login_required\` redirect for both the framed \`session\` view and the \`session_delete\` view at the terminal \`/workshops/finished/\` page, with \`?notification=session-expired\`. Django's \`redirect_to_login\` preserves the existing query string while appending \`next\`, so the finished view reads \`session-expired\` and renders a message specific to this case. A new branch is added to \`finished.html\` for that notification.

Template + decorator changes only — no migrations, no dependency changes.

## Verification

- Confirmed Django's \`redirect_to_login\` produces \`/workshops/finished/?notification=session-expired&next=…\`, so the notification survives.
- In-cluster: hitting the session delete URL without a valid login session lands on the finished page showing the expired message, instead of the portal login page; normal authenticated session-end flow is unchanged.

Release note added under *Features Changed* in \`project-docs/release-notes/version-4.0.0.md\`.