### PR TITLE
Update base-environment workshop image to Fedora 44.

### DIFF
--- a/workshop-images/base-environment/Dockerfile
+++ b/workshop-images/base-environment/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM kubernetesui/dashboard:v2.7.0 AS k8s-console
 
-FROM fedora:42 AS system-base
+FROM fedora:44 AS system-base
 
 RUN HOME=/root && \
     INSTALL_PKGS=" \


### PR DESCRIPTION
Updates the `base-environment` workshop image base from `fedora:42` to `fedora:44`. This is the last of the workshop/backend images to move to Fedora 44.

Verified the docker-ce repo publishes Fedora 44 packages (x86_64 + aarch64) and that all installed packages remain available in Fedora 44 — no package renames needed. The substantive change is system `python3` moving 3.13 → 3.14; the `/opt/httpd` mod_wsgi build and dashboard were confirmed working in-cluster under Python 3.14.

Downstream `jdk*`, `desktop`, and `conda` environments build `FROM` this image and inherit the change on rebuild.

Adjacent version bumps (Node 20 → 24 LTS, the `golang:1.19-buster` git-serve builder) are intentionally deferred to a separate change to keep the Fedora bump isolated.