### PR TITLE
Schedule initial reserved session creation off the global lock

### DIFF
--- a/training-portal/src/project/apps/workshops/manager/environments.py
+++ b/training-portal/src/project/apps/workshops/manager/environments.py
@@ -23,7 +23,7 @@ from .locking import resources_lock
 from .sessions import (
     update_session_status,
     setup_workshop_session,
-    create_workshop_session,
+    create_reserved_session,
 )
 from .analytics import report_analytics_event
 
@@ -273,7 +273,7 @@ def activate_workshop_environment(resource):
             )
 
             for session, secret in sessions:
-                create_workshop_session(session, secret)
+                create_reserved_session(session, secret).schedule()
 
     transaction.on_commit(_schedule_session_creation)
 


### PR DESCRIPTION
## Summary

Follow-up to the training portal lock-contention work (#1073, #656). An audit of the
remaining `transaction.on_commit` callbacks found one case where multiple Kubernetes
resources were still being created under a single acquisition of the global resources
lock.

When a workshop environment becomes ready, `activate_workshop_environment` creates its
initial reserved sessions. It did this by calling `create_workshop_session` in a loop
from an `on_commit` callback. Because `on_commit` callbacks run before the global lock
is released, all of those WorkshopSession creations ran under one lock acquisition,
blocking other session activity for the duration of the whole batch.

## What changed

Each initial reserved session is now deployed in its own task via
`create_reserved_session(...).schedule()`, so the lock is released between sessions
rather than held across the whole batch. This matches the treatment already applied to
`initiate_reserved_sessions`, and closes the last unbounded fan-out under a single lock
acquisition.

## Testing

Validated in-cluster by provisioning a workshop environment with multiple initial
reserved sessions and confirming they are created correctly.