### PR TITLE
Shift bundled kubectl range to 1.33-1.36 and update embedded kind to 0.32

### DIFF
--- a/client-programs/go.mod
+++ b/client-programs/go.mod
@@ -38,7 +38,7 @@ require (
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/kubectl v0.34.2
 	sigs.k8s.io/controller-runtime v0.22.4
-	sigs.k8s.io/kind v0.29.0
+	sigs.k8s.io/kind v0.32.0
 	sigs.k8s.io/yaml v1.6.0
 )
 

--- a/client-programs/go.sum
+++ b/client-programs/go.sum
@@ -581,8 +581,8 @@ sigs.k8s.io/controller-runtime v0.22.4 h1:GEjV7KV3TY8e+tJ2LCTxUTanW4z/FmNB7l327U
 sigs.k8s.io/controller-runtime v0.22.4/go.mod h1:+QX1XUpTXN4mLoblf4tqr5CQcyHPAki2HLXqQMY6vh8=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
-sigs.k8s.io/kind v0.29.0 h1:3TpCsyh908IkXXpcSnsMjWdwdWjIl7o9IMZImZCWFnI=
-sigs.k8s.io/kind v0.29.0/go.mod h1:ldWQisw2NYyM6k64o/tkZng/1qQW7OlzcN5a8geJX3o=
+sigs.k8s.io/kind v0.32.0 h1:p9hscbj98u/qyrjVpjId86LI70nQmbSsipV7wCG10Xk=
+sigs.k8s.io/kind v0.32.0/go.mod h1:FSqriGaoTPruiXWfRnUXNykF8r2t+fHtK0P0m1AbGF8=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
 sigs.k8s.io/structured-merge-diff/v6 v6.3.0 h1:jTijUJbW353oVOd9oTlifJqOGEkUw2jB/fXCbTiQEco=

--- a/project-docs/release-notes/version-4.0.0.md
+++ b/project-docs/release-notes/version-4.0.0.md
@@ -75,6 +75,12 @@ Features Changed
   therefore see a larger client/server version skew and should be verified
   against a supported cluster version.
 
+* The version of ``kind`` embedded in the ``educates`` CLI has been updated
+  from 0.29 to 0.32. As a result the default Kubernetes version used when
+  creating a local cluster with ``educates local cluster create`` has changed
+  from 1.33 to 1.36. A specific node image can still be selected using the
+  ``--kind-cluster-image`` option if a different Kubernetes version is required.
+
 Bugs Fixed
 ----------
 

--- a/project-docs/release-notes/version-4.0.0.md
+++ b/project-docs/release-notes/version-4.0.0.md
@@ -64,6 +64,17 @@ Features Changed
   the ``helm`` CLI should be verified against the newer Helm version to ensure
   they still behave as expected.
 
+* The set of ``kubectl`` versions bundled in the workshop base environment
+  image has changed. The 1.31 and 1.32 versions have been dropped and 1.35 and
+  1.36 have been added, so the supported range is now 1.33 to 1.36. The
+  ``kubectl`` version is still selected automatically to match the Kubernetes
+  cluster the workshop session is connected to. For clusters older than the
+  supported range the oldest bundled version, 1.33, is used, and for clusters
+  newer than the supported range the most recent bundled version, 1.36, is
+  used. Workshops which target clusters running Kubernetes 1.32 or older may
+  therefore see a larger client/server version skew and should be verified
+  against a supported cluster version.
+
 Bugs Fixed
 ----------
 

--- a/workshop-images/base-environment/Dockerfile
+++ b/workshop-images/base-environment/Dockerfile
@@ -166,36 +166,6 @@ EOF
 RUN mkdir -p /opt/kubernetes/bin
 
 RUN <<EOF
-    KUBECTL_VERSION=1.31.14
-    KUBECTL_SHORT_VERSION=$(echo ${KUBECTL_VERSION} | cut -d. -f1,2)
-    CHECKSUM_amd64="46336f34b10d686c4dd83f977e39df51df77b85c2211f9c0187c2e4c6257ea27d63f29893255d9edfa9b0459013a305736a27c1d00e6062e8c3c7f9056d5543e"
-    CHECKSUM_arm64="a8b96f6c0c0274ee2a8a48d2333c1eea03c3427b772858231d8e211c16d66a75933e5bcf6d0f15f7c88063ca7a629e53d4d8934f9de5293708f6a5d07f98d4e2"
-    CHECKSUM=CHECKSUM_${TARGETARCH}
-    set -eo pipefail
-    curl --silent --fail -L -o /tmp/kubernetes-client-linux-${TARGETARCH}.tar.gz https://dl.k8s.io/v${KUBECTL_VERSION}/kubernetes-client-linux-${TARGETARCH}.tar.gz
-    echo "${!CHECKSUM} /tmp/kubernetes-client-linux-${TARGETARCH}.tar.gz" | sha512sum --check --status
-    tar -C /opt/kubernetes/bin --strip-components 3 -zxf /tmp/kubernetes-client-linux-${TARGETARCH}.tar.gz kubernetes/client/bin/kubectl kubernetes/client/bin/kubectl-convert
-    mv /opt/kubernetes/bin/kubectl /opt/kubernetes/bin/kubectl@${KUBECTL_SHORT_VERSION}
-    mv /opt/kubernetes/bin/kubectl-convert /opt/kubernetes/bin/kubectl-convert@${KUBECTL_SHORT_VERSION}
-    rm -f /tmp/kubernetes-client-linux-${TARGETARCH}.tar.gz
-EOF
-
-RUN <<EOF
-    KUBECTL_VERSION=1.32.13
-    KUBECTL_SHORT_VERSION=$(echo ${KUBECTL_VERSION} | cut -d. -f1,2)
-    CHECKSUM_amd64="8e8cd19c13eac67a26554623635707db9e0bd18808e5313f0cdf3efb6babfbe3ddb2abd927dfe07e22d6340beeebd2d12fe650ac0a91da3da119a91511ad5107"
-    CHECKSUM_arm64="5d85848b0af95c5147f20a889a85d1ecc4ab31f3ff87b4674638423855b68cad98082cc2bbc195b86ed982914da72bc95c0d4a8346c21fd09ac135c086f172e4"
-    CHECKSUM=CHECKSUM_${TARGETARCH}
-    set -eo pipefail
-    curl --silent --fail -L -o /tmp/kubernetes-client-linux-${TARGETARCH}.tar.gz https://dl.k8s.io/v${KUBECTL_VERSION}/kubernetes-client-linux-${TARGETARCH}.tar.gz
-    echo "${!CHECKSUM} /tmp/kubernetes-client-linux-${TARGETARCH}.tar.gz" | sha512sum --check --status
-    tar -C /opt/kubernetes/bin --strip-components 3 -zxf /tmp/kubernetes-client-linux-${TARGETARCH}.tar.gz kubernetes/client/bin/kubectl kubernetes/client/bin/kubectl-convert
-    mv /opt/kubernetes/bin/kubectl /opt/kubernetes/bin/kubectl@${KUBECTL_SHORT_VERSION}
-    mv /opt/kubernetes/bin/kubectl-convert /opt/kubernetes/bin/kubectl-convert@${KUBECTL_SHORT_VERSION}
-    rm -f /tmp/kubernetes-client-linux-${TARGETARCH}.tar.gz
-EOF
-
-RUN <<EOF
     KUBECTL_VERSION=1.33.13
     KUBECTL_SHORT_VERSION=$(echo ${KUBECTL_VERSION} | cut -d. -f1,2)
     CHECKSUM_amd64="7365f43aa89d666d66840935756a32978320eb9a1c92e8c07d6f8bbd76fccfa7e5f18a2393065dd242057f93750823255bed5be8f4eab3729af57cda578096e7"
@@ -215,6 +185,36 @@ RUN <<EOF
     KUBECTL_SHORT_VERSION=$(echo ${KUBECTL_VERSION} | cut -d. -f1,2)
     CHECKSUM_amd64="2900328c7a2f60c512a18bba05a14b2db208611bbf5b173a6e8f231079d1dcdf29febcab86dbef89396f3f3493af59eacd1f3eff4ccd32828b64d56e161599f2"
     CHECKSUM_arm64="0221cf4859f756849e10429280e3fdb9f803d67fedfe752c662522847f28004c010487a1e0323acc3fe29efc47de49c0cf5d87e2366a325dda559699c2ea249d"
+    CHECKSUM=CHECKSUM_${TARGETARCH}
+    set -eo pipefail
+    curl --silent --fail -L -o /tmp/kubernetes-client-linux-${TARGETARCH}.tar.gz https://dl.k8s.io/v${KUBECTL_VERSION}/kubernetes-client-linux-${TARGETARCH}.tar.gz
+    echo "${!CHECKSUM} /tmp/kubernetes-client-linux-${TARGETARCH}.tar.gz" | sha512sum --check --status
+    tar -C /opt/kubernetes/bin --strip-components 3 -zxf /tmp/kubernetes-client-linux-${TARGETARCH}.tar.gz kubernetes/client/bin/kubectl kubernetes/client/bin/kubectl-convert
+    mv /opt/kubernetes/bin/kubectl /opt/kubernetes/bin/kubectl@${KUBECTL_SHORT_VERSION}
+    mv /opt/kubernetes/bin/kubectl-convert /opt/kubernetes/bin/kubectl-convert@${KUBECTL_SHORT_VERSION}
+    rm -f /tmp/kubernetes-client-linux-${TARGETARCH}.tar.gz
+EOF
+
+RUN <<EOF
+    KUBECTL_VERSION=1.35.6
+    KUBECTL_SHORT_VERSION=$(echo ${KUBECTL_VERSION} | cut -d. -f1,2)
+    CHECKSUM_amd64="4fea6a8b5711b439585cca7972aa5032dd631d10ff5c5c68c8335d6bf592e1d1e2a3b3fb560f0db38656e9c7233965e7f80bbf9eeeb2b3ed91040f22260bacc7"
+    CHECKSUM_arm64="d045aa8a79997a42f6e97f6d7fa7bdf493dd7693e0ac64d79800ad1674a6b4e7e3606179e63d3e3a5661d5e8de4f0acb7fef69f5c47561c1be65c577f7b11a98"
+    CHECKSUM=CHECKSUM_${TARGETARCH}
+    set -eo pipefail
+    curl --silent --fail -L -o /tmp/kubernetes-client-linux-${TARGETARCH}.tar.gz https://dl.k8s.io/v${KUBECTL_VERSION}/kubernetes-client-linux-${TARGETARCH}.tar.gz
+    echo "${!CHECKSUM} /tmp/kubernetes-client-linux-${TARGETARCH}.tar.gz" | sha512sum --check --status
+    tar -C /opt/kubernetes/bin --strip-components 3 -zxf /tmp/kubernetes-client-linux-${TARGETARCH}.tar.gz kubernetes/client/bin/kubectl kubernetes/client/bin/kubectl-convert
+    mv /opt/kubernetes/bin/kubectl /opt/kubernetes/bin/kubectl@${KUBECTL_SHORT_VERSION}
+    mv /opt/kubernetes/bin/kubectl-convert /opt/kubernetes/bin/kubectl-convert@${KUBECTL_SHORT_VERSION}
+    rm -f /tmp/kubernetes-client-linux-${TARGETARCH}.tar.gz
+EOF
+
+RUN <<EOF
+    KUBECTL_VERSION=1.36.2
+    KUBECTL_SHORT_VERSION=$(echo ${KUBECTL_VERSION} | cut -d. -f1,2)
+    CHECKSUM_amd64="bf3fa2fe065af663b944acdef42ab61a0062e01d325d60d756aaab22bb412addc2ffa77fdcb39de47560c5613a9bcd68e67ea83417626aefbe52db9cc76fde7d"
+    CHECKSUM_arm64="ef798cdab3538164ecd6b3c1987c69e4094c14d3e88a31811964cd0b57536a4b488b0b9f37a4ad7139d25f1b73c019d2791f9e58017cce929bc0e8262484496d"
     CHECKSUM=CHECKSUM_${TARGETARCH}
     set -eo pipefail
     curl --silent --fail -L -o /tmp/kubernetes-client-linux-${TARGETARCH}.tar.gz https://dl.k8s.io/v${KUBECTL_VERSION}/kubernetes-client-linux-${TARGETARCH}.tar.gz

--- a/workshop-images/base-environment/opt/eduk8s/etc/setup.d/01-kubernetes.sh
+++ b/workshop-images/base-environment/opt/eduk8s/etc/setup.d/01-kubernetes.sh
@@ -43,13 +43,10 @@ KUBECTL_VERSION=$(kubectl version -o json | jq -re '[.serverVersion.major,.serve
 
 case "$KUBECTL_VERSION" in
 1.2*)
-    KUBECTL_VERSION=1.31
+    KUBECTL_VERSION=1.33
     ;;
-1.3[01])
-    KUBECTL_VERSION=1.31
-    ;;
-1.32)
-    KUBECTL_VERSION=1.32
+1.3[012])
+    KUBECTL_VERSION=1.33
     ;;
 1.33)
     KUBECTL_VERSION=1.33
@@ -57,14 +54,16 @@ case "$KUBECTL_VERSION" in
 1.34)
     KUBECTL_VERSION=1.34
     ;;
-1.3*)
-    KUBECTL_VERSION=1.34
+1.35)
+    KUBECTL_VERSION=1.35
+    ;;
+1.36)
+    KUBECTL_VERSION=1.36
+    ;;
+*)
+    KUBECTL_VERSION=1.36
     ;;
 esac
-
-if [ -z "$KUBECTL_VERSION" ]; then
-    KUBECTL_VERSION=1.34
-fi
 
 # Restrict access permissions on kubeconfig file as some clients will complain
 # if it is readable by group or others.

--- a/workshop-images/base-environment/opt/kubernetes/bin/kubectl
+++ b/workshop-images/base-environment/opt/kubernetes/bin/kubectl
@@ -2,13 +2,10 @@
 
 case "$KUBECTL_VERSION" in
 1.2*)
-    KUBECTL_VERSION=1.31
+    KUBECTL_VERSION=1.33
     ;;
-1.3[01])
-    KUBECTL_VERSION=1.31
-    ;;
-1.32)
-    KUBECTL_VERSION=1.32
+1.3[012])
+    KUBECTL_VERSION=1.33
     ;;
 1.33)
     KUBECTL_VERSION=1.33
@@ -16,17 +13,19 @@ case "$KUBECTL_VERSION" in
 1.34)
     KUBECTL_VERSION=1.34
     ;;
-1.3*)
-    KUBECTL_VERSION=1.34
+1.35)
+    KUBECTL_VERSION=1.35
+    ;;
+1.36)
+    KUBECTL_VERSION=1.36
+    ;;
+*)
+    KUBECTL_VERSION=1.36
     ;;
 esac
 
-if [ -z "$KUBECTL_VERSION" ]; then
-    KUBECTL_VERSION=1.34
-fi
-
 if [ ! -x /opt/kubernetes/bin/kubectl@$KUBECTL_VERSION ]; then
-    KUBECTL_VERSION=1.34
+    KUBECTL_VERSION=1.36
 fi
 
 exec /opt/kubernetes/bin/kubectl@$KUBECTL_VERSION "$@"

--- a/workshop-images/base-environment/opt/kubernetes/bin/kubectl-convert
+++ b/workshop-images/base-environment/opt/kubernetes/bin/kubectl-convert
@@ -2,13 +2,10 @@
 
 case "$KUBECTL_VERSION" in
 1.2*)
-    KUBECTL_VERSION=1.31
+    KUBECTL_VERSION=1.33
     ;;
-1.3[01])
-    KUBECTL_VERSION=1.31
-    ;;
-1.32)
-    KUBECTL_VERSION=1.32
+1.3[012])
+    KUBECTL_VERSION=1.33
     ;;
 1.33)
     KUBECTL_VERSION=1.33
@@ -16,17 +13,19 @@ case "$KUBECTL_VERSION" in
 1.34)
     KUBECTL_VERSION=1.34
     ;;
-1.3*)
-    KUBECTL_VERSION=1.34
+1.35)
+    KUBECTL_VERSION=1.35
+    ;;
+1.36)
+    KUBECTL_VERSION=1.36
+    ;;
+*)
+    KUBECTL_VERSION=1.36
     ;;
 esac
 
-if [ -z "$KUBECTL_VERSION" ]; then
-    KUBECTL_VERSION=1.34
-fi
-
 if [ ! -x /opt/kubernetes/bin/kubectl-convert@$KUBECTL_VERSION ]; then
-    KUBECTL_VERSION=1.34
+    KUBECTL_VERSION=1.36
 fi
 
 exec /opt/kubernetes/bin/kubectl-convert@$KUBECTL_VERSION "$@"


### PR DESCRIPTION
## Summary

Updates the Kubernetes client tooling versions in the workshop base environment image and the kind version embedded in the `educates` CLI, keeping the two aligned.

### Bundled kubectl range → 1.33–1.36
- Drops the kubectl `1.31` and `1.32` builds from the base environment image and adds `1.35.6` and `1.36.2` (verified amd64 + arm64 sha512 checksums). Bundled set is now `1.33.13 / 1.34.9 / 1.35.6 / 1.36.2`.
- Updates the version selector in the kubernetes setup script (`01-kubernetes.sh`) and the `kubectl` / `kubectl-convert` wrappers so:
  - cluster versions in 1.33–1.36 select the matching client,
  - clusters older than 1.33 fall back to **1.33**,
  - newer or unrecognised versions fall back to **1.36**.

### Embedded kind → 0.32.0
- Bumps `sigs.k8s.io/kind` from `0.29.0` to `0.32.0` in `client-programs`. This moves the default Kubernetes version for `educates local cluster create` from 1.33 to **1.36.1**, aligning the local-cluster default with the bundled kubectl range. `--kind-cluster-image` still overrides per-invocation.
- Clean bump: one line in `go.mod`, no transitive dependency churn; CLI builds with no code changes.

### Release notes
Adds bullets covering the kubectl supported-range change (and its skew caveat for ≤1.32 clusters) and the kind/default-Kubernetes-version change.

## Testing
- Base environment kubectl selector scripts pass `bash -n`; checksums verified against `dl.k8s.io`.
- `client-programs` builds successfully with kind 0.32.0; built binary embeds `kindest/node:v1.36.1`.
- A real `educates local cluster create` smoke test against 1.36.1 is still recommended before release.