### PR TITLE
Add missing publish-client-programs dependency to release-artifacts job

### DIFF
--- a/.github/workflows/build-and-publish-images.yaml
+++ b/.github/workflows/build-and-publish-images.yaml
@@ -884,6 +884,7 @@ jobs:
       - build-client-programs-linux-arm64
       - build-client-programs-darwin-amd64
       - build-client-programs-darwin-arm64
+      - publish-client-programs
       - publish-docker-extension
 
     steps:


### PR DESCRIPTION
## Summary

The `release-artifacts` job in the build-and-publish-images workflow did not list `publish-client-programs` in its `needs`. As a result the job would run regardless of whether publishing the client programs had succeeded — a failure in `publish-client-programs` would not stop release artifacts from being assembled against missing or stale client programs.

This adds `publish-client-programs` to the `needs` of `release-artifacts`, so the job only runs after `publish-client-programs` has completed successfully and is skipped if that job fails.

## Testing

Single-line workflow dependency addition; effective once exercised by a release build.