### PR TITLE
Derive session ingress hostnames from session namespace not name

### DIFF
--- a/session-manager/handlers/application_git.py
+++ b/session-manager/handlers/application_git.py
@@ -9,7 +9,7 @@ from .helpers import substitute_variables
 def git_workshop_spec_patches(workshop_spec, application_properties):
     characters = string.ascii_letters + string.digits
 
-    git_host = f"git-$(session_name).{INGRESS_DOMAIN}"
+    git_host = f"git-$(session_namespace).{INGRESS_DOMAIN}"
     git_username = "$(session_name)"
     git_password = "$(services_password)"
 

--- a/workshop-images/base-environment/opt/gateway/src/backend/modules/proxy.ts
+++ b/workshop-images/base-environment/opt/gateway/src/backend/modules/proxy.ts
@@ -28,14 +28,14 @@ export function setup_proxy(app: express.Application, auth: string) {
             }
 
             // For a specific ingress, we need to match a host name where the
-            // session name is either prefixed or suffixed with the name of the
-            // ingress. Note that suffix use is deprecated but need to support
-            // it for backwards compatibility.
+            // session namespace is either prefixed or suffixed with the name of
+            // the ingress. Note that suffix use is deprecated but need to
+            // support it for backwards compatibility.
 
             let hosts = []
 
-            hosts.push(`${name}-${config.session_name}.${config.ingress_domain}`)
-            hosts.push(`${config.session_name}-${name}.${config.ingress_domain}`)
+            hosts.push(`${name}-${config.session_namespace}.${config.ingress_domain}`)
+            hosts.push(`${config.session_namespace}-${name}.${config.ingress_domain}`)
 
             // The filter/router function should only match and return a target
             // for requests that are actually for the calculated host names.


### PR DESCRIPTION
## Summary

Aligns two places that built session ingress hostnames from the session **name** so they instead derive from the session **namespace**, matching how the session manager actually generates the per-session Ingress hostnames.

- **Gateway proxy** ([`proxy.ts`](workshop-images/base-environment/opt/gateway/src/backend/modules/proxy.ts)): secondary-ingress host matching now keys off `config.session_namespace` instead of `config.session_name`.
- **git application** ([`application_git.py`](session-manager/handlers/application_git.py)): `git_host` now uses `$(session_namespace)` instead of `$(session_name)`.

## Why

The operator builds every per-session Ingress hostname from `session_namespace` (`<environment-name>-<session-id>`), never from the WorkshopSession's `metadata.name`. The two sites changed here used the name instead. These only coincide when a session is named by the `<environment-name>-<session-id>` convention — which the training portal and WorkshopRequest paths always enforce.

A `WorkshopSession` created **directly** with a name that doesn't follow that convention would:
- have secondary ingress requests (`<name>-<session-namespace>`) fail to match in the gateway proxy and fall through to a redirect to `/dashboard/`; and
- be handed a `git_host` that doesn't match the routable git Ingress.

## Scope / impact

No behavioural change on supported creation paths (portal, WorkshopRequest), where name and namespace already match — this is an internal alignment that makes the behaviour correct for directly-created sessions. No release note (per discussion). This is the minimal, targeted fix; the broader session-hostname consolidation is deferred until CRD changes can be made.

## Testing

The gateway change is TypeScript built into the base-environment image, so it needs an image rebuild and in-cluster verification.