### PR TITLE
Document stabilized patch releases for support lines in git workflow

### DIFF
--- a/.claude/skills/educates-git-workflow/references/cut-release-branch.md
+++ b/.claude/skills/educates-git-workflow/references/cut-release-branch.md
@@ -7,6 +7,12 @@ version.
 
 Maintainer operation: direct clone only, never from a fork.
 
+Its default base is `develop`. There is one other case: a **stabilized patch release
+of a maintained line**, where `release/X.Y.Z` is cut from a `support/X.Y.x` branch
+instead. That variant is driven from `references/support-and-hotfix.md` (Path B); the
+mechanics below are otherwise the same, reading `support/X.Y.x` for `develop` as the
+base and skipping the develop-specific feature-freeze framing.
+
 ## Ask first
 
 - Confirm the user is declaring feature freeze now. Do not cut a release branch as a

--- a/.claude/skills/educates-git-workflow/references/finish-release.md
+++ b/.claude/skills/educates-git-workflow/references/finish-release.md
@@ -7,6 +7,14 @@ multiple turns, waiting on the user at each human step.
 
 Maintainer operation: direct clone only.
 
+This describes finishing a **primary-line** release: `release/X.Y.Z` cut from
+`develop`, merged to `main`, tagged there, and back-merged to `develop`. A
+**stabilized patch release of a maintained line** finishes differently — it merges
+back into its `support/X.Y.x` branch, is tagged on that support branch, and is **not**
+back-merged to `develop`. That variant is driven from
+`references/support-and-hotfix.md` (Path B); do not apply the `main`/`develop` targets
+of the stages below to it.
+
 ## Stage 0: pre-flight and plan
 
 After the universal pre-flight:

--- a/.claude/skills/educates-git-workflow/references/support-and-hotfix.md
+++ b/.claude/skills/educates-git-workflow/references/support-and-hotfix.md
@@ -26,7 +26,25 @@ git switch -c support/3.7.x 3.7.0
 
 1. [confirm] `git push -u origin support/3.7.x`
 
-## Patch a support line (hotfix)
+## Two ways to patch a support line
+
+Once the line exists, a patch release is built one of two ways. Which one is the
+user's call; ask if it is not clear:
+
+- **Path A — direct hotfix.** A single, self-contained fix that needs no pre-release
+  validation. The fix goes on a `hotfix/*` branch, PRs straight back to the support
+  branch, and the final tag is applied on the support branch. This is the default for
+  simple patches.
+- **Path B — stabilized patch release.** The patch needs rc builds first, or bundles
+  several changes (often back-ports) that should stabilize together before shipping.
+  A `release/X.Y.Z` branch is cut *from the support branch* and stabilized there, with
+  rc tags, exactly as an imminent primary-line release is — only the support branch,
+  not `main`/`develop`, is the base it returns to.
+
+Both paths end with a final `X.Y.Z` tag on the support branch, and both must consider
+propagation to other lines (see "Propagating across lines" at the end).
+
+## Path A — direct hotfix
 
 Ask first: the next patch version for the line (check existing tags:
 `git tag -l '3.7.*'`).
@@ -47,15 +65,84 @@ Then, gated:
 2. [confirm] `gh pr create --base support/3.7.x --head hotfix/3.7.1 --title "Fix ... (3.7.1)"`
 
 Stop; human reviews and merges in the UI. Merges to `support/*` go through PRs, the
-same as `main` and `develop`.
+same as `main` and `develop`. Then tag the patch release (see "Tag the patch release").
+
+## Path B — stabilized patch release
+
+Use when the patch needs rc builds, or batches several changes (often back-ports)
+together. The support branch plays the role `main`+`develop` play for a primary-line
+release: the release branch is cut from it, stabilized, and finished back into it.
+
+Ask first: the target patch version `X.Y.Z` (check `git tag -l '3.7.*'`).
+
+Checks, after the universal pre-flight:
+
+- Local `support/X.Y.x` is up to date with origin.
+- `X.Y.Z` does not already exist as a tag, locally or on origin.
+- `release/X.Y.Z` does not already exist on origin.
+
+### Cut the release branch from the support line
+
+This is the one deviation from `references/cut-release-branch.md`, whose default base
+is `develop`; here the base is the support branch.
+
+```
+git switch support/3.7.x
+git pull --ff-only
+git switch -c release/3.7.3
+```
+
+Then, gated:
+
+1. [confirm] `git push -u origin release/3.7.3`
+
+### Stabilize on the release branch
+
+Assemble the patch here as ordinary stabilization work:
+
+- Cherry-pick the back-ported commit(s), oldest-first, per
+  `references/propagate-fixes.md`. If a cherry-pick carries a newer version's
+  release-notes file, see "Back-porting changes that carry newer-version release
+  notes" below.
+- Add the `version-X.Y.Z.md` release notes and the `project-docs/index.rst` entry.
+
+rc builds are tagged on this `release/X.Y.Z` branch via `references/tag-prerelease.md`.
+No change to the tag-placement rule is needed: the rc sits on a `release/*` branch,
+which is exactly where rc tags belong. If an rc is bad, fix on the release branch and
+tag the next rc number; never re-tag.
+
+### Finish the patch release
+
+When an rc is blessed, finish much like `references/finish-release.md`, but the base
+is the support branch, not `main`:
+
+1. [confirm] `gh pr create --base support/3.7.x --head release/3.7.3 --title "Release 3.7.3"`
+
+   The `--base` is the **support branch**, not `main` and not `develop`. Double-check
+   it; this is the classic slip. Stop; a human reviews and merges in the UI.
+
+After the PR merges, tag the final release on the support branch (see "Tag the patch
+release"), then, gated:
+
+2. [confirm] `git push origin --delete release/3.7.3`
+
+   The `release/X.Y.Z` branch is ephemeral and deleted once finished; also delete the
+   local copy. The `support/X.Y.x` line is permanent and is never deleted.
+
+**No back-merge into `develop`.** A primary-line release back-merges to `develop`; a
+support-line release does not. develop is a separate, later line, so propagation to it
+(and to other maintained lines) is handled deliberately via
+`references/propagate-fixes.md`, not by merging the support branch. In the common case
+the changes were back-ported *from* develop and are already there.
 
 ## Tag the patch release
 
-After the hotfix PR is merged. Patch releases get release notes like any other
-release, so before tagging, check
+Used by both paths, after the fix/PR is merged into `support/X.Y.x`. Patch releases get
+release notes like any other release, so before tagging, check
 `git show origin/support/3.7.x:project-docs/release-notes/version-3.7.1.md` succeeds
 and `project-docs/index.rst` on that branch references `release-notes/version-3.7.1`.
-If missing, stop; add the notes through the hotfix/PR flow first.
+If missing, stop; add the notes through the hotfix/PR (Path A) or release-branch
+(Path B) flow first.
 
 ```
 git switch support/3.7.x
@@ -63,11 +150,62 @@ git pull --ff-only
 git tag 3.7.1
 ```
 
-3. [confirm] `git push origin 3.7.1`
+- [confirm] `git push origin 3.7.1`
 
 Placement check applies: a final-format tag on a support branch must sit on that
 support branch. The pushed tag triggers the same CI release build as any release.
 
-Then ask: does this fix affect other maintained lines or develop? If yes, continue
-with `references/propagate-fixes.md`. Treat "applied to every affected maintained
-line, including develop" as a required checklist item, especially for security fixes.
+## Back-porting changes that carry newer-version release notes
+
+A back-ported commit was authored against a newer line, so it may add or edit a
+release-notes file for a **future** version (e.g. `version-4.0.0.md`). That file must
+not ride along onto the older line: the notes belong under the version actually being
+shipped (`version-X.Y.Z.md`), and the newer file usually does not exist on the older
+line, so a plain cherry-pick throws a modify/delete conflict anyway.
+
+Separate the code change from the notes:
+
+1. Before dropping anything, capture the note text:
+   `git show <sha> -- project-docs/release-notes/version-<newer>.md`.
+2. Cherry-pick with `--no-commit` so the staged set can be pruned:
+   ```
+   git cherry-pick -n <sha>
+   ```
+3. Drop the newer notes from the staged set (the modify/delete conflict is the signal
+   that a foreign notes file was coming across; resolving it *is* the drop). Also
+   remove any `release-notes/version-<newer>` line the commit added to
+   `project-docs/index.rst`:
+   ```
+   git rm project-docs/release-notes/version-<newer>.md
+   # revert the version-<newer> toctree entry in project-docs/index.rst
+   ```
+4. Commit only the code change, reusing the original message and author:
+   ```
+   git commit -C <sha>
+   ```
+5. Reland the wording under the release being built: fold it into `version-X.Y.Z.md`
+   as part of the normal release-notes commit — not a separate one.
+
+Only apply this to commits that actually touch a notes file; cherry-pick the rest
+normally.
+
+Adapting the note for `X.Y.Z`:
+
+- Write it as a **first-class change in the release being shipped**, not as a
+  back-port. Release notes describe what changed for the reader; provenance (that it
+  was back-ported, and from where) belongs in the commit message and PR, not the notes.
+- **Do not forward-reference.** Strip wording tied to the newer version — feature
+  names, "new in X.Y", or a version number the reader of the older line is not running.
+- **Keep shared identifiers.** Carry over issue or CVE references (e.g. `#1073`, an
+  advisory ID); they let users correlate the same fix across lines.
+- **Keep wording consistent across lines.** When the same fix ships on several
+  maintained lines and develop, phrase each line's note the same way so readers
+  recognize it as the same underlying fix — this does the job "back-ported" would,
+  without the confusing version reference.
+
+## Propagating across lines
+
+After either path, ask: does this fix affect other maintained lines or develop? If yes,
+continue with `references/propagate-fixes.md`. Treat "applied to every affected
+maintained line, including develop" as a required checklist item, especially for
+security fixes.

--- a/.claude/skills/educates-git-workflow/references/tag-prerelease.md
+++ b/.claude/skills/educates-git-workflow/references/tag-prerelease.md
@@ -4,7 +4,10 @@ Pre-release tags trigger the CI build and produce a GitHub release marked
 pre-release. Placement is the rule this skill enforces, because GitHub cannot:
 
 - `X.Y.Z-alpha.N` and `X.Y.Z-beta.N`: on `develop`, before feature freeze.
-- `X.Y.Z-rc.N`: on the `release/X.Y.Z` branch, after feature freeze.
+- `X.Y.Z-rc.N`: on the `release/X.Y.Z` branch, after feature freeze. This holds
+  whether the release branch was cut from `develop` or, for a stabilized patch release
+  of a maintained line, from a `support/X.Y.x` branch — an rc always sits on its
+  `release/X.Y.Z` branch.
 
 Maintainer operation: direct clone only.
 

--- a/developer-docs/branching-strategy.md
+++ b/developer-docs/branching-strategy.md
@@ -16,7 +16,7 @@ Branch Overview
 | `develop` | Integration line for the line under development (4.x in this example); alpha/beta tags are made here | `main` |
 | `support/<major>.<minor>.x` | Optional, on-demand maintenance line for a release line that needs patching; several can exist at once (e.g. `support/3.6.x`, `support/3.7.x`) | `main`, at that line's latest release tag, created only when a need to patch it arises |
 | `feature/4.0/*` | Individual features for the line under development | `develop` |
-| `release/<major>.<minor>.<patch>` | Stabilizing an imminent release; rc tags are made here (e.g. `release/4.0.0`) | `develop` |
+| `release/<major>.<minor>.<patch>` | Stabilizing an imminent release; rc tags are made here (e.g. `release/4.0.0`) | `develop`; or a `support/<major>.<minor>.x` branch for a stabilized patch release of a maintained line |
 | `bugfix/<desc>` | A non-feature fix; for the in-development line, or for a release found broken during stabilization | `develop`, or the `release/` branch being stabilized |
 | `hotfix/<major>.<minor>.z` | A single fix for a maintained line | the matching `support/<major>.<minor>.x` |
 
@@ -89,7 +89,7 @@ Do **not** merge `develop` into the `release/` branch to pull in a change. That 
 Maintenance of Released Lines
 -----------------------------
 
-A released line that needs patching after the fact gets an on-demand `support/<major>.<minor>.x` branch, cut from `main` at that line's latest release tag. Individual fixes for it are made on `hotfix/*` branches off the support branch, and patch releases are tagged on the support branch. A fix that affects more than one maintained line, security fixes in particular, must land on **all** affected lines that are still maintained, including `develop`.
+A released line that needs patching after the fact gets an on-demand `support/<major>.<minor>.x` branch, cut from `main` at that line's latest release tag. Most patches are a single fix made on a `hotfix/*` branch off the support branch, with the patch release tagged on the support branch. When a patch needs pre-release (rc) builds, or bundles several changes (often back-ports) that should stabilize together, a `release/<major>.<minor>.<patch>` branch is instead cut from the support branch, stabilized there with rc tags, and merged back into the support branch before the final tag — the same release-branch machinery as the primary line, but based on the support branch rather than `develop`/`main`, and with no back-merge to `develop`. A fix that affects more than one maintained line, security fixes in particular, must land on **all** affected lines that are still maintained, including `develop`.
 
 The mechanics of opening support lines, applying hotfixes, tagging patch releases, and propagating fixes across lines are maintainer operations covered in the [release procedures](release-procedures.md).
 


### PR DESCRIPTION
Documents a second path for patching a maintained (support) line in the
educates-git-workflow skill and the branching strategy.

- Path A (existing): a single fix on a hotfix/* branch, PR'd back to the
  support branch, tagged on the support branch.
- Path B (new): for patches that need rc builds or bundle several back-ports,
  cut a release/X.Y.Z branch from the support branch, stabilize with rc tags,
  PR back into the support branch, tag the final release there, delete the
  release branch. No back-merge to develop.

Also adds guidance for back-porting commits that carry a newer version's
release-notes file: drop the newer file via a no-commit cherry-pick and
migrate the note into the release actually being built, written as a
first-class change without forward-references.