### PR TITLE
Update JDK workshop base environments to latest Temurin, Maven and Gradle versions

### DIFF
--- a/project-docs/release-notes/version-4.0.0.md
+++ b/project-docs/release-notes/version-4.0.0.md
@@ -331,6 +331,27 @@ Deprecations
   therefore see a larger client/server version skew and should be verified
   against a supported cluster version.
 
+* The JDK versions included in the ``jdk8-environment``, ``jdk11-environment``,
+  ``jdk17-environment`` and ``jdk21-environment`` workshop base images have
+  been updated to the latest Eclipse Temurin patch releases, being 8u492-b09,
+  11.0.31+11, 17.0.19+10 and 21.0.11+10 respectively. The bundled Maven and
+  Gradle versions have also been updated. All four images now include Maven
+  3.9.16. The ``jdk8-environment`` and ``jdk11-environment`` images include
+  Gradle 8.14.5, the latest version able to run on those JDK versions, while
+  the ``jdk17-environment`` and ``jdk21-environment`` images include Gradle
+  9.6.1. Gradle 9 is a new major release which introduces breaking changes
+  relative to Gradle 8, so any workshops which use Gradle in the JDK 17 or
+  JDK 21 images should be verified against the newer Gradle version to ensure
+  they still behave as expected. One behaviour change affects all four
+  images: ``gradle init`` now aborts if the target directory already
+  contains any files, including hidden files, where previously it would
+  generate the new project alongside them. Since the home directory of a
+  workshop session is never empty, any workshop which has users run
+  ``gradle init`` directly in the home directory, or any other non-empty
+  directory, will need its instructions updated to either pass the
+  ``--overwrite`` option to ``gradle init`` or create the project in a new
+  empty subdirectory.
+
 * The ``vcluster`` software used by the ``vcluster`` workshop application has
   been updated from 0.30.2 to 0.35.2, and the set of Kubernetes versions the
   virtual cluster can provision has been aligned with the versions supported

--- a/workshop-images/jdk11-environment/Dockerfile
+++ b/workshop-images/jdk11-environment/Dockerfile
@@ -15,25 +15,25 @@ RUN <<EOF
     ARCHNAME_amd64=x64
     ARCHNAME_arm64=aarch64
     ARCHNAME=ARCHNAME_${TARGETARCH}
-    CHECKSUM_amd64="7dfd551795a8884b26cbb02e0301da95db40160bb194f48271dc2ef9367f50c2"
-    CHECKSUM_arm64="32c316cb3998a9c9dee2829fbb577ea1c0ed666700cec73e049d44c342bb19af"
+    CHECKSUM_amd64="1e9de64586b519c0a981319489257cabedd9457599f3823424a87c3158fbe939"
+    CHECKSUM_arm64="257f4d39e060658fc2eb89a803ca43b3f337e64e253f2d94ebae1d85c9ef5f69"
     CHECKSUM=CHECKSUM_${TARGETARCH}
-    curl --fail -sL -o /tmp/jdk11.tar.gz https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.28%2B6/OpenJDK11U-jdk_${!ARCHNAME}_linux_hotspot_11.0.28_6.tar.gz
+    curl --fail -sL -o /tmp/jdk11.tar.gz https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.31%2B11/OpenJDK11U-jdk_${!ARCHNAME}_linux_hotspot_11.0.31_11.tar.gz
     echo "${!CHECKSUM} /tmp/jdk11.tar.gz" | sha256sum --check --status
     tar -C /opt/java --strip-components 1 -zxf /tmp/jdk11.tar.gz
     rm /tmp/jdk11.tar.gz
 EOF
 
-RUN curl --fail -sL -o /tmp/maven.tar.gz https://archive.apache.org/dist/maven/maven-3/3.9.11/binaries/apache-maven-3.9.11-bin.tar.gz && \
-    echo "bcfe4fe305c962ace56ac7b5fc7a08b87d5abd8b7e89027ab251069faebee516b0ded8961445d6d91ec1985dfe30f8153268843c89aa392733d1a3ec956c9978 /tmp/maven.tar.gz" | sha512sum --check --status && \
+RUN curl --fail -sL -o /tmp/maven.tar.gz https://archive.apache.org/dist/maven/maven-3/3.9.16/binaries/apache-maven-3.9.16-bin.tar.gz && \
+    echo "831a8591fe20c8243b1dbe7d71e3244f31d1665b0804b2e825e38cbbe5ce0cafb8338851f90780735568773e0a6cd07bbec107cda0b896b008b861075358b6f6 /tmp/maven.tar.gz" | sha512sum --check --status && \
     tar -C /opt/maven --strip-components 1 -zxf /tmp/maven.tar.gz && \
     rm /tmp/maven.tar.gz
 
-RUN curl --fail -sL -o /tmp/gradle.zip https://services.gradle.org/distributions/gradle-8.5-bin.zip && \
-    echo "9d926787066a081739e8200858338b4a69e837c3a821a33aca9db09dd4a41026 /tmp/gradle.zip" | sha256sum --check --status && \
+RUN curl --fail -sL -o /tmp/gradle.zip https://services.gradle.org/distributions/gradle-8.14.5-bin.zip && \
+    echo "6f74b601422d6d6fc4e1f9a1ab6522f642c2fdcbc15ae33ebd30ba3d7198e854 /tmp/gradle.zip" | sha256sum --check --status && \
     unzip -d /opt/gradle /tmp/gradle.zip && \
-    mv /opt/gradle/gradle-8.5/* /opt/gradle/ && \
-    rm -rf /opt/gradle/gradle-8.5 && \
+    mv /opt/gradle/gradle-8.14.5/* /opt/gradle/ && \
+    rm -rf /opt/gradle/gradle-8.14.5 && \
     rm /tmp/gradle.zip
 
 ENV PATH=/opt/java/bin:/opt/gradle/bin:/opt/maven/bin:$PATH \
@@ -46,8 +46,8 @@ RUN mvn archetype:generate -DgroupId=com.mycompany.app -DartifactId=my-app \
     cd my-app && \
     mvn wrapper:wrapper
 
-RUN gradle init && \
-    gradle wrapper --gradle-version=8.5 --distribution-type=bin && \
+RUN gradle init --overwrite && \
+    gradle wrapper --gradle-version=8.14.5 --distribution-type=bin && \
     ./gradlew build
 
 FROM ${IMAGE_REPOSITORY}/${BASE_IMAGE_NAME}:${PACKAGE_VERSION}

--- a/workshop-images/jdk17-environment/Dockerfile
+++ b/workshop-images/jdk17-environment/Dockerfile
@@ -15,25 +15,25 @@ RUN <<EOF
     ARCHNAME_amd64=x64
     ARCHNAME_arm64=aarch64
     ARCHNAME=ARCHNAME_${TARGETARCH}
-    CHECKSUM_amd64="166774efcf0f722f2ee18eba0039de2d685b350ee14d7b69e6f83437dafd2af1"
-    CHECKSUM_arm64="423416447885d9e45f96dd9e0b2c1367da5e1b0353e187cfdf9388c9820ac147"
+    CHECKSUM_amd64="d8afc263758141a66e0e3aafc321e783f7016696f4eaea067d340a269037d331"
+    CHECKSUM_arm64="83a52172678ec8975164648654869cb2e71d7c748b47aca94b29bbfa10c18e81"
     CHECKSUM=CHECKSUM_${TARGETARCH}
-    curl --fail -sL -o /tmp/jdk17.tar.gz https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.16%2B8/OpenJDK17U-jdk_${!ARCHNAME}_linux_hotspot_17.0.16_8.tar.gz
+    curl --fail -sL -o /tmp/jdk17.tar.gz https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.19%2B10/OpenJDK17U-jdk_${!ARCHNAME}_linux_hotspot_17.0.19_10.tar.gz
     echo "${!CHECKSUM} /tmp/jdk17.tar.gz" | sha256sum --check --status
     tar -C /opt/java --strip-components 1 -zxf /tmp/jdk17.tar.gz
     rm /tmp/jdk17.tar.gz
 EOF
 
-RUN curl --fail -sL -o /tmp/maven.tar.gz https://archive.apache.org/dist/maven/maven-3/3.9.11/binaries/apache-maven-3.9.11-bin.tar.gz && \
-    echo "bcfe4fe305c962ace56ac7b5fc7a08b87d5abd8b7e89027ab251069faebee516b0ded8961445d6d91ec1985dfe30f8153268843c89aa392733d1a3ec956c9978 /tmp/maven.tar.gz" | sha512sum --check --status && \
+RUN curl --fail -sL -o /tmp/maven.tar.gz https://archive.apache.org/dist/maven/maven-3/3.9.16/binaries/apache-maven-3.9.16-bin.tar.gz && \
+    echo "831a8591fe20c8243b1dbe7d71e3244f31d1665b0804b2e825e38cbbe5ce0cafb8338851f90780735568773e0a6cd07bbec107cda0b896b008b861075358b6f6 /tmp/maven.tar.gz" | sha512sum --check --status && \
     tar -C /opt/maven --strip-components 1 -zxf /tmp/maven.tar.gz && \
     rm /tmp/maven.tar.gz
 
-RUN curl --fail -sL -o /tmp/gradle.zip https://services.gradle.org/distributions/gradle-8.5-bin.zip && \
-    echo "9d926787066a081739e8200858338b4a69e837c3a821a33aca9db09dd4a41026 /tmp/gradle.zip" | sha256sum --check --status && \
+RUN curl --fail -sL -o /tmp/gradle.zip https://services.gradle.org/distributions/gradle-9.6.1-bin.zip && \
+    echo "9c0f7faeeb306cb14e4279a3e084ca6b596894089a0638e68a07c945a32c9e14 /tmp/gradle.zip" | sha256sum --check --status && \
     unzip -d /opt/gradle /tmp/gradle.zip && \
-    mv /opt/gradle/gradle-8.5/* /opt/gradle/ && \
-    rm -rf /opt/gradle/gradle-8.5 && \
+    mv /opt/gradle/gradle-9.6.1/* /opt/gradle/ && \
+    rm -rf /opt/gradle/gradle-9.6.1 && \
     rm /tmp/gradle.zip
 
 ENV PATH=/opt/java/bin:/opt/gradle/bin:/opt/maven/bin:$PATH \
@@ -46,8 +46,8 @@ RUN mvn archetype:generate -DgroupId=com.mycompany.app -DartifactId=my-app \
     cd my-app && \
     mvn wrapper:wrapper
 
-RUN gradle init && \
-    gradle wrapper --gradle-version=8.5 --distribution-type=bin && \
+RUN gradle init --overwrite && \
+    gradle wrapper --gradle-version=9.6.1 --distribution-type=bin && \
     ./gradlew build
 
 FROM ${IMAGE_REPOSITORY}/${BASE_IMAGE_NAME}:${PACKAGE_VERSION}

--- a/workshop-images/jdk21-environment/Dockerfile
+++ b/workshop-images/jdk21-environment/Dockerfile
@@ -15,25 +15,25 @@ RUN <<EOF
     ARCHNAME_amd64=x64
     ARCHNAME_arm64=aarch64
     ARCHNAME=ARCHNAME_${TARGETARCH}
-    CHECKSUM_amd64="f2dc5418092c43003db8f9005c4a286e1c0104fea96ccdd49e8ebd037cac9219"
-    CHECKSUM_arm64="e5c41a1ab0865ea5de9b4529bf8526005f1d4593090845387d14fe450ce39c33"
+    CHECKSUM_amd64="4b2220e232a97997b436ca6ab15cbf70171ecff52958a46159dfa5a8c44ca4de"
+    CHECKSUM_arm64="8d498ec88e1c1989fab95c6784240ab92d011e29c54d20a3f9c324b13476f9ad"
     CHECKSUM=CHECKSUM_${TARGETARCH}
-    curl --fail -sL -o /tmp/jdk21.tar.gz https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.8%2B9/OpenJDK21U-jdk_${!ARCHNAME}_linux_hotspot_21.0.8_9.tar.gz
+    curl --fail -sL -o /tmp/jdk21.tar.gz https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.11%2B10/OpenJDK21U-jdk_${!ARCHNAME}_linux_hotspot_21.0.11_10.tar.gz
     echo "${!CHECKSUM} /tmp/jdk21.tar.gz" | sha256sum --check --status
     tar -C /opt/java --strip-components 1 -zxf /tmp/jdk21.tar.gz
     rm /tmp/jdk21.tar.gz
 EOF
 
-RUN curl --fail -sL -o /tmp/maven.tar.gz https://archive.apache.org/dist/maven/maven-3/3.9.11/binaries/apache-maven-3.9.11-bin.tar.gz && \
-    echo "bcfe4fe305c962ace56ac7b5fc7a08b87d5abd8b7e89027ab251069faebee516b0ded8961445d6d91ec1985dfe30f8153268843c89aa392733d1a3ec956c9978 /tmp/maven.tar.gz" | sha512sum --check --status && \
+RUN curl --fail -sL -o /tmp/maven.tar.gz https://archive.apache.org/dist/maven/maven-3/3.9.16/binaries/apache-maven-3.9.16-bin.tar.gz && \
+    echo "831a8591fe20c8243b1dbe7d71e3244f31d1665b0804b2e825e38cbbe5ce0cafb8338851f90780735568773e0a6cd07bbec107cda0b896b008b861075358b6f6 /tmp/maven.tar.gz" | sha512sum --check --status && \
     tar -C /opt/maven --strip-components 1 -zxf /tmp/maven.tar.gz && \
     rm /tmp/maven.tar.gz
 
-    RUN curl --fail -sL -o /tmp/gradle.zip https://services.gradle.org/distributions/gradle-8.8-bin.zip && \
-    echo "a4b4158601f8636cdeeab09bd76afb640030bb5b144aafe261a5e8af027dc612 /tmp/gradle.zip" | sha256sum --check --status && \
+RUN curl --fail -sL -o /tmp/gradle.zip https://services.gradle.org/distributions/gradle-9.6.1-bin.zip && \
+    echo "9c0f7faeeb306cb14e4279a3e084ca6b596894089a0638e68a07c945a32c9e14 /tmp/gradle.zip" | sha256sum --check --status && \
     unzip -d /opt/gradle /tmp/gradle.zip && \
-    mv /opt/gradle/gradle-8.8/* /opt/gradle/ && \
-    rm -rf /opt/gradle/gradle-8.8 && \
+    mv /opt/gradle/gradle-9.6.1/* /opt/gradle/ && \
+    rm -rf /opt/gradle/gradle-9.6.1 && \
     rm /tmp/gradle.zip
 
 ENV PATH=/opt/java/bin:/opt/gradle/bin:/opt/maven/bin:$PATH \
@@ -58,8 +58,8 @@ RUN if [ "${TARGETARCH}" = "arm64" ]; then \
         export JAVA_OPTS="-XX:UseSVE=0"; \
         mv gradle.properties-arm64 gradle.properties; \
     fi && \
-    gradle init && \
-    gradle wrapper --gradle-version=8.8 --distribution-type=bin && \
+    gradle init --overwrite && \
+    gradle wrapper --gradle-version=9.6.1 --distribution-type=bin && \
     ./gradlew build
 
 FROM ${IMAGE_REPOSITORY}/${BASE_IMAGE_NAME}:${PACKAGE_VERSION}

--- a/workshop-images/jdk8-environment/Dockerfile
+++ b/workshop-images/jdk8-environment/Dockerfile
@@ -15,25 +15,25 @@ RUN <<EOF
     ARCHNAME_amd64=x64
     ARCHNAME_arm64=aarch64
     ARCHNAME=ARCHNAME_${TARGETARCH}
-    CHECKSUM_amd64="5d64ae542b59a962b3caadadd346f4b1c3010879a28bb02d928326993de16e79"
-    CHECKSUM_arm64="19552c1cf7f5c18290a6bdcd6757f70ea5c331a2bc0dd7a3b3120e8dbc4b4891"
+    CHECKSUM_amd64="da257f161d7f8c6ca5b0e5d9e4090f65ac28c5e398072e68b8ae87988b1d1a2e"
+    CHECKSUM_arm64="3c2253b986909c20f79d6de7a0cb957f89c243df57615897836046e24d2e5257"
     CHECKSUM=CHECKSUM_${TARGETARCH}
-    curl --fail -sL -o /tmp/jdk8.tar.gz https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u462-b08/OpenJDK8U-jdk_${!ARCHNAME}_linux_hotspot_8u462b08.tar.gz
+    curl --fail -sL -o /tmp/jdk8.tar.gz https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u492-b09/OpenJDK8U-jdk_${!ARCHNAME}_linux_hotspot_8u492b09.tar.gz
     echo "${!CHECKSUM} /tmp/jdk8.tar.gz" | sha256sum --check --status
     tar -C /opt/java --strip-components 1 -zxf /tmp/jdk8.tar.gz
     rm /tmp/jdk8.tar.gz
 EOF
 
-RUN curl --fail -sL -o /tmp/maven.tar.gz https://archive.apache.org/dist/maven/maven-3/3.9.11/binaries/apache-maven-3.9.11-bin.tar.gz && \
-    echo "bcfe4fe305c962ace56ac7b5fc7a08b87d5abd8b7e89027ab251069faebee516b0ded8961445d6d91ec1985dfe30f8153268843c89aa392733d1a3ec956c9978 /tmp/maven.tar.gz" | sha512sum --check --status && \
+RUN curl --fail -sL -o /tmp/maven.tar.gz https://archive.apache.org/dist/maven/maven-3/3.9.16/binaries/apache-maven-3.9.16-bin.tar.gz && \
+    echo "831a8591fe20c8243b1dbe7d71e3244f31d1665b0804b2e825e38cbbe5ce0cafb8338851f90780735568773e0a6cd07bbec107cda0b896b008b861075358b6f6 /tmp/maven.tar.gz" | sha512sum --check --status && \
     tar -C /opt/maven --strip-components 1 -zxf /tmp/maven.tar.gz && \
     rm /tmp/maven.tar.gz
 
-RUN curl --fail -sL -o /tmp/gradle.zip https://services.gradle.org/distributions/gradle-8.5-bin.zip && \
-    echo "9d926787066a081739e8200858338b4a69e837c3a821a33aca9db09dd4a41026 /tmp/gradle.zip" | sha256sum --check --status && \
+RUN curl --fail -sL -o /tmp/gradle.zip https://services.gradle.org/distributions/gradle-8.14.5-bin.zip && \
+    echo "6f74b601422d6d6fc4e1f9a1ab6522f642c2fdcbc15ae33ebd30ba3d7198e854 /tmp/gradle.zip" | sha256sum --check --status && \
     unzip -d /opt/gradle /tmp/gradle.zip && \
-    mv /opt/gradle/gradle-8.5/* /opt/gradle/ && \
-    rm -rf /opt/gradle/gradle-8.5 && \
+    mv /opt/gradle/gradle-8.14.5/* /opt/gradle/ && \
+    rm -rf /opt/gradle/gradle-8.14.5 && \
     rm /tmp/gradle.zip
 
 ENV PATH=/opt/java/bin:/opt/gradle/bin:/opt/maven/bin:$PATH \
@@ -46,8 +46,8 @@ RUN mvn archetype:generate -DgroupId=com.mycompany.app -DartifactId=my-app \
     cd my-app && \
     mvn wrapper:wrapper
 
-RUN gradle init && \
-    gradle wrapper --gradle-version=8.5 --distribution-type=bin && \
+RUN gradle init --overwrite && \
+    gradle wrapper --gradle-version=8.14.5 --distribution-type=bin && \
     ./gradlew build
 
 FROM ${IMAGE_REPOSITORY}/${BASE_IMAGE_NAME}:${PACKAGE_VERSION}


### PR DESCRIPTION
Updates the JDK workshop base environment images to the latest Eclipse Temurin patch releases (April 2026 CPU, the newest builds Adoptium has published):

| Image | JDK | Maven | Gradle |
|---|---|---|---|
| jdk8-environment | 8u462-b08 → 8u492-b09 | 3.9.11 → 3.9.16 | 8.5 → 8.14.5 |
| jdk11-environment | 11.0.28+6 → 11.0.31+11 | 3.9.11 → 3.9.16 | 8.5 → 8.14.5 |
| jdk17-environment | 17.0.16+8 → 17.0.19+10 | 3.9.11 → 3.9.16 | 8.5 → 9.6.1 |
| jdk21-environment | 21.0.8+9 → 21.0.11+10 | 3.9.11 → 3.9.16 | 8.8 → 9.6.1 |

Gradle versions follow the official compatibility matrix: Gradle 9 requires JVM 17+ to run, so the JDK 8 and 11 images take 8.14.5 (the last 8.x line) while the JDK 17 and 21 images move to the current 9.6.1.

Newer Gradle versions abort `gradle init` when the target directory already contains files (including hidden files), so the cache priming step in the image builds now passes `--overwrite`. This same behaviour change affects workshops that run `gradle init` in a non-empty directory such as the session home directory, and is called out in the release notes.

Verified against the built images with networking disabled that the prepopulated `.m2` and `.gradle` caches are still used by the new Maven and Gradle versions: the Gradle wrapper distribution, `gradle init`/`gradle wrapper` and the Maven archetype and wrapper flows all work offline, matching the behaviour of the previously published images.