### PR TITLE
Remove arm64 UseSVE workaround from jdk21-environment image build

### DIFF
--- a/workshop-images/jdk21-environment/Dockerfile
+++ b/workshop-images/jdk21-environment/Dockerfile
@@ -41,24 +41,13 @@ ENV PATH=/opt/java/bin:/opt/gradle/bin:/opt/maven/bin:$PATH \
     M2_HOME=/opt/maven \
     GRADLE_HOME=/opt/gradle
 
-COPY gradle.properties-arm64 .
-
-RUN if [ "${TARGETARCH}" = "arm64" ]; then \
-        export MAVEN_OPTS="-XX:UseSVE=0"; \
-        export JAVA_OPTS="-XX:UseSVE=0"; \
-    fi && \
-    mvn archetype:generate -DgroupId=com.mycompany.app -DartifactId=my-app \
+RUN mvn archetype:generate -DgroupId=com.mycompany.app -DartifactId=my-app \
         -DarchetypeArtifactId=maven-archetype-quickstart \
         -DarchetypeVersion=1.4 -DinteractiveMode=false && \
     cd my-app && \
     mvn wrapper:wrapper
 
-RUN if [ "${TARGETARCH}" = "arm64" ]; then \
-        export MAVEN_OPTS="-XX:UseSVE=0"; \
-        export JAVA_OPTS="-XX:UseSVE=0"; \
-        mv gradle.properties-arm64 gradle.properties; \
-    fi && \
-    gradle init --overwrite && \
+RUN gradle init --overwrite && \
     gradle wrapper --gradle-version=9.6.1 --distribution-type=bin && \
     ./gradlew build
 

--- a/workshop-images/jdk21-environment/gradle.properties-arm64
+++ b/workshop-images/jdk21-environment/gradle.properties-arm64
@@ -1,1 +1,0 @@
-org.gradle.jvmargs="-XX:UseSVE=0"


### PR DESCRIPTION
The `4.0.0-alpha.8` release build failed for the jdk21-environment image on arm64: the arm64 build hack moves a root-owned `gradle.properties` into the home directory before `gradle init`, and Gradle 9's `init` task now generates its own `gradle.properties`, failing with `AccessDeniedException` when it attempts to overwrite the root-owned file (the `COPY` had no `--chown`). amd64 was unaffected because the move is skipped there.

Rather than adapt the workaround, this removes it entirely. It existed for [JDK-8345296](https://bugs.openjdk.org/browse/JDK-8345296) — the JVM crashed with SIGILL on aarch64 hosts that disallow the `prctl` syscall (such as the GitHub Actions arm64 runners) when probing the SVE vector length. That was [fixed upstream](https://github.com/openjdk/jdk/pull/22479) and backported to JDK 21.0.6 (January 2025); the image is now on 21.0.11, so the JVM handles the failed probe by disabling SVE itself.

Removes the `gradle.properties-arm64` file, its `COPY`, and the arm64-conditional `MAVEN_OPTS`/`JAVA_OPTS` exports, bringing the jdk21 build steps back in line with the other JDK images. Nothing shipped in the final image changes — the workaround only ever applied to the scratch-stage cache priming.

Verified with a local `linux/arm64` build of the image, which now completes successfully.