### PR TITLE
build: remove installer/operator/bin in prune-builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -373,6 +373,7 @@ prune-builds:
 	rm -rf training-portal/venv
 	rm -rf client-programs/bin
 	rm -rf client-programs/pkg/renderer/files
+	rm -rf installer/operator/bin
 	rm -rf project-docs/venv
 	rm -rf project-docs/_build
 


### PR DESCRIPTION
The operator Makefile downloads tool binaries (`controller-gen`, envtest) into `installer/operator/bin`, which is ignored via the kubebuilder-scaffolded `installer/operator/.gitignore` on `develop`. Older support branches have no `installer` directory at all, so after switching to one the leftover binaries show up as untracked files. Prune the directory in `prune-builds` alongside the other downloaded and derived build artifacts.