### PR TITLE
docs(release): delete the remote back-merge branch when finishing a release

### DIFF
--- a/.claude/skills/educates-git-workflow/references/finish-release.md
+++ b/.claude/skills/educates-git-workflow/references/finish-release.md
@@ -81,12 +81,19 @@ automatic. Then, gated:
 
 Stop. Human reviews and merges in the UI.
 
-## Stage 4: delete the finished release branch
+## Stage 4: delete the finished release and back-merge branches
 
-Only after the back-merge PR is merged, so nothing is lost. The release branch is
+Only after the back-merge PR is merged, so nothing is lost. Both branches are
 ephemeral; the permanent record is the tag plus the merge commits.
 
 5. [confirm] `git push origin --delete release/4.1.0`
+6. [confirm] `git push origin --delete merge/4.1.0-to-develop`
+
+The remote `merge/4.1.0-to-develop` branch may already be gone if the reviewer
+deleted it from the PR page when merging the back-merge PR, or if the repository
+auto-deletes head branches; check with `git ls-remote --heads origin
+merge/4.1.0-to-develop` and skip the deletion if so. Do not rely on that having
+happened: an undeleted back-merge branch lingers silently otherwise.
 
 Also delete the local `release/4.1.0` and `merge/4.1.0-to-develop` branches (low
 risk, but mention it).

--- a/developer-docs/release-procedures.md
+++ b/developer-docs/release-procedures.md
@@ -184,13 +184,14 @@ git push -u origin merge/4.0.0-to-develop
 gh pr create --base develop --head merge/4.0.0-to-develop --title "Back-merge 4.0.0 into develop"
 #    (or open in the UI) - review and merge the PR.
 
-# 4. Delete the finished release branch
+# 4. Delete the finished release and back-merge branches
 git push origin --delete release/4.0.0
+git push origin --delete merge/4.0.0-to-develop
 ```
 
 The format of the tag for a final release is `X.Y.Z`, with no suffix. `main` only ever carries final release tags. Pushing the tag triggers the GitHub actions workflow, which produces the full set of release artifacts described above, and a GitHub release not marked as pre-release.
 
-The back-merge in step 3 ensures the release's stabilization fixes, and the release/version-bump commits, are not lost, and that `develop` reflects exactly what shipped. The release branch is ephemeral: once merged and tagged it has done its job, and the permanent record is the tag plus the merge commits, not the branch. Deleting it (step 4) is a deliberate, explicit step; keep it on the release checklist so stale `release/*` branches don't accumulate.
+The back-merge in step 3 ensures the release's stabilization fixes, and the release/version-bump commits, are not lost, and that `develop` reflects exactly what shipped. The release branch and the `merge/X.Y.Z-to-develop` branch are both ephemeral: once merged and tagged they have done their job, and the permanent record is the tag plus the merge commits, not the branches. Deleting them (step 4) is a deliberate, explicit step; keep it on the release checklist so stale `release/*` and `merge/*` branches don't accumulate. The remote `merge/*` branch may already have been deleted from the PR page when the back-merge PR was merged, in which case the second delete in step 4 simply fails with "remote ref does not exist" and can be ignored, but do not rely on that having happened: an undeleted back-merge branch lingers silently otherwise.
 
 Once the workflow completes, verify the release is installable from the published artifacts alone:
 


### PR DESCRIPTION
The finish-release checklist only deleted the remote `release/*` branch. The remote `merge/X.Y.Z-to-develop` branch created for the back-merge PR was left to the GitHub PR page's delete button, and lingered when that wasn't used, as happened with `merge/3.7.2-to-develop` after the 3.7.2 release (back-merge PR #1085 was merged but the branch survived until manually deleted).

This makes deletion of the remote back-merge branch an explicit step:

- `developer-docs/release-procedures.md`: step 4 of the finish-release recipe now deletes both the `release/X.Y.Z` and `merge/X.Y.Z-to-develop` remote branches, and the surrounding prose explains both branches are ephemeral and that the delete may be a no-op if the branch was already removed from the PR page.
- `.claude/skills/educates-git-workflow/references/finish-release.md`: Stage 4 gains a gated step to delete the remote back-merge branch, with a check for it having already been removed at PR-merge time.