### PR TITLE
Release 3.7.3

### DIFF
--- a/project-docs/index.rst
+++ b/project-docs/index.rst
@@ -96,6 +96,7 @@ Educates
   :maxdepth: 2
   :caption: Release Notes:
 
+  release-notes/version-3.7.3
   release-notes/version-3.7.2
   release-notes/version-3.7.1
   release-notes/version-3.7.0

--- a/project-docs/release-notes/version-3.7.3.md
+++ b/project-docs/release-notes/version-3.7.3.md
@@ -1,6 +1,10 @@
 Version 3.7.3
 =============
 
+This version is a patch release of the 3.7 support line. The changes in this
+release were developed on the main development branch for the upcoming 4.0
+release and have been back ported to the 3.7 support line.
+
 Features Changed
 ----------------
 

--- a/project-docs/release-notes/version-3.7.3.md
+++ b/project-docs/release-notes/version-3.7.3.md
@@ -1,0 +1,15 @@
+Version 3.7.3
+=============
+
+Features Changed
+----------------
+
+* The training portal has been made more resilient when allocating and
+  managing workshop sessions under load. Previously, when many sessions were
+  being requested at the same time, or when the Kubernetes REST API was slow
+  to respond or applying throttling, session allocation could fail or requests
+  could back up, sometimes surfacing as a `database is locked` error or as
+  failed or timed out session requests. Updates the training portal makes to
+  Kubernetes are now performed in a way that no longer blocks other session
+  activity while waiting on the Kubernetes API, reducing failed sessions and
+  improving reliability under high traffic.

--- a/training-portal/src/project/apps/workshops/manager/cleanup.py
+++ b/training-portal/src/project/apps/workshops/manager/cleanup.py
@@ -16,6 +16,8 @@ from django.db import transaction
 from django.utils import timezone
 from django.contrib.auth import get_user_model
 
+from oauth2_provider.models import clear_expired
+
 from ..models import SessionState, Session
 
 from .sessions import replace_reserved_session
@@ -230,38 +232,33 @@ def delete_workshop_session(session):
 
 
 @background_task
-@resources_lock
+@transaction.atomic
 def cleanup_old_sessions_and_users():
-    """Delete records for any sessions older than a certain time, and then
-    remove any anonymous user accounts that have no active sessions and which
-    are older than a certain time.
+    """Delete records for any sessions older than a certain time, remove any
+    anonymous user accounts that have no active sessions and which are older
+    than a certain time, and clear expired OAuth tokens.
 
     """
 
-    with transaction.atomic():
-        # Delete record of workshop sessions more than 36 hours old.
+    cutoff = timezone.now() - timedelta(hours=36)
 
-        cutoff = timezone.now() - timedelta(hours=36)
+    # Delete records of workshop sessions more than 36 hours old.
 
-        sessions = Session.objects.filter(
-            state=SessionState.STOPPED, expires__lte=cutoff
-        )
+    Session.objects.filter(state=SessionState.STOPPED, expires__lte=cutoff).delete()
 
-        for session in sessions:
-            logger.info("Cleanup old workshop session %s.", session.name)
-            session.delete()
+    # Delete anonymous users more than 36 hours old that no longer have any
+    # workshop sessions associated with them. Filtering on session__isnull=True
+    # restricts the delete to users with no sessions, so it is a single atomic
+    # operation that never trips the PROTECT constraint on Session.owner.
 
-        # Delete any anonymous users older than 36 hours old, which
-        # now don't have any workshop sessions associated with them.
+    User = get_user_model()  # pylint: disable=invalid-name
 
-        User = get_user_model()  # pylint: disable=invalid-name
+    User.objects.filter(
+        groups__name="anonymous",
+        date_joined__lte=cutoff,
+        session__isnull=True,
+    ).delete()
 
-        users = User.objects.filter(groups__name="anonymous", date_joined__lte=cutoff)
+    # Clear expired OAuth tokens.
 
-        for user in users:
-            sessions = Session.objects.filter(owner=user)
-
-            if not sessions:
-                logger.info("Deleting anonymous user %s.", user.get_username())
-                report_analytics_event(user, "User/Delete", {"group": "anonymous"})
-                user.delete()
+    clear_expired()

--- a/training-portal/src/project/apps/workshops/manager/cleanup.py
+++ b/training-portal/src/project/apps/workshops/manager/cleanup.py
@@ -28,30 +28,50 @@ logger = logging.getLogger("educates")
 api = pykube.HTTPClient(pykube.KubeConfig.from_env())
 
 
+# Minimum age a workshop session record must reach before the reaper will treat
+# a missing Kubernetes resource as a sign the session was deleted out of band.
+# This avoids racing with a session whose resource is still being created.
+
+VANISHED_SESSION_GRACE_PERIOD = timedelta(minutes=2)
+
+
 @background_task
-@resources_lock
-@transaction.atomic
 def purge_expired_workshop_sessions():
     """Look for workshop sessions which have expired and delete them."""
 
     now = timezone.now()
 
-    # Loop over all records of workshop sessions in the database and check
-    # whether any should be deleted and/or marked as stopped.
+    # Take a snapshot of the workshop session records up front, then perform the
+    # per-session Kubernetes and HTTP checks below without holding the global
+    # resources lock or an open database transaction. Each check makes
+    # synchronous network calls, and a slow Kubernetes API or an unresponsive
+    # session pod must not be able to stall other portal activity (session
+    # allocation, the reconcile loop, operator events) for the duration. The
+    # actual deletions are handed off to delete_workshop_session() which manages
+    # its own lock and transaction.
 
     K8SWorkshopSession = pykube.object_factory(
         api, "training.educates.dev/v1beta1", "WorkshopSession"
     )
 
-    for session in Session.objects.all():
-        if not session.is_starting() and not session.is_stopped():
-            # If the workshop session isn't still starting, and hasn't stopped
-            # yet, check to see whether there is a deployed workshop session.
-            # If there isn't, it means it was deleted manually. In this case
-            # trigger a task to clean up the workshop session. In this case
-            # there will be no deployment to delete, but still have to mark
-            # the workshop session as deleted in the database.
+    for session in list(Session.objects.select_related("environment").all()):
+        # If the workshop session isn't still starting, and hasn't stopped yet,
+        # check whether there is a deployed workshop session. If there isn't, it
+        # means it was deleted manually, so trigger a task to clean it up (there
+        # will be no deployment to delete, but the database record still needs
+        # to be marked as deleted). Require the session to have existed for at
+        # least a grace period first, so a session whose Kubernetes resource is
+        # still being created is never mistaken for one that has vanished; it
+        # will be reconsidered on a later pass.
 
+        if (
+            not session.is_starting()
+            and not session.is_stopped()
+            and (
+                session.created is None
+                or (now - session.created) >= VANISHED_SESSION_GRACE_PERIOD
+            )
+        ):
             try:
                 K8SWorkshopSession.objects(api).get(name=session.name)
 
@@ -105,7 +125,7 @@ def purge_expired_workshop_sessions():
 
                     url = f"http://{session.name}.{session.environment.name}/session/activity"
 
-                    response = requests.get(url)
+                    response = requests.get(url, timeout=2.5)
 
                     if response.status_code == 200:
                         # If got a response and we have exceeded the
@@ -147,12 +167,15 @@ def purge_expired_workshop_sessions():
 
                         pass
 
-                except requests.exceptions.ConnectionError:
-                    # XXX This can just be because it is slow to start up.
-                    # Need a better method to determine if was running but has
-                    # since failed in some way and become uncontactable. In
-                    # that case right now will only be deleted when workshop
-                    # timeout expires if there is one.
+                except (
+                    requests.exceptions.ConnectionError,
+                    requests.exceptions.Timeout,
+                ):
+                    # XXX This can just be because it is slow to start up, or
+                    # the probe timed out. Need a better method to determine if
+                    # was running but has since failed in some way and become
+                    # uncontactable. In that case right now will only be deleted
+                    # when workshop timeout expires if there is one.
 
                     logger.warning(
                         "Cannot connect to workshop session %s.", session.name

--- a/training-portal/src/project/apps/workshops/manager/environments.py
+++ b/training-portal/src/project/apps/workshops/manager/environments.py
@@ -23,7 +23,7 @@ from .locking import resources_lock
 from .sessions import (
     update_session_status,
     setup_workshop_session,
-    create_workshop_session,
+    create_reserved_session,
 )
 from .analytics import report_analytics_event
 
@@ -273,7 +273,7 @@ def activate_workshop_environment(resource):
             )
 
             for session, secret in sessions:
-                create_workshop_session(session, secret)
+                create_reserved_session(session, secret).schedule()
 
     transaction.on_commit(_schedule_session_creation)
 

--- a/training-portal/src/project/apps/workshops/manager/environments.py
+++ b/training-portal/src/project/apps/workshops/manager/environments.py
@@ -299,6 +299,13 @@ def shutdown_workshop_environments(training_portal, workshops):
 
     environments = training_portal.active_environments()
 
+    # Collect the names of environments and sessions being stopped so the
+    # Kubernetes status updates can be deferred until after the transaction
+    # commits, keeping the K8s calls out from under the SQLite write lock.
+
+    stopping_environments = []
+    stopping_sessions = []
+
     for environment in environments:
         workshop_key = f"{environment.workshop_name}:{environment.resource_name}"
 
@@ -323,14 +330,27 @@ def shutdown_workshop_environments(training_portal, workshops):
             else:
                 logger.info("Stopping workshop environment %s.", environment.name)
 
-            update_environment_status(environment.name, "Stopping")
             environment.mark_as_stopping()
             report_analytics_event(environment, "Environment/Terminate")
+            stopping_environments.append(environment.name)
 
             for session in environment.available_sessions():
-                update_session_status(session.name, "Stopping")
                 session.mark_as_stopping()
                 report_analytics_event(session, "Session/Terminate")
+                stopping_sessions.append(session.name)
+
+    # Defer the Kubernetes status updates until after the transaction commits so
+    # the write lock is released first.
+
+    if stopping_environments or stopping_sessions:
+
+        def _update_stopping_status():
+            for name in stopping_environments:
+                update_environment_status(name, "Stopping")
+            for name in stopping_sessions:
+                update_session_status(name, "Stopping")
+
+        transaction.on_commit(_update_stopping_status)
 
 
 @background_task
@@ -405,6 +425,12 @@ def delete_workshop_environments(training_portal):
 def update_workshop_environments(training_portal, workshops):
     """Updates configuration of any workshops which already exist."""
 
+    # Collect the status detail updates so the Kubernetes writes can be deferred
+    # until after the transaction commits, keeping the K8s calls out from under
+    # the SQLite write lock.
+
+    status_details = []
+
     for position, workshop in enumerate(workshops, 1):
         workshop_name = workshop.get("alias", "") or workshop["name"]
 
@@ -440,9 +466,20 @@ def update_workshop_environments(training_portal, workshops):
 
             environment.save()
 
-            update_environment_status_details(
-                environment.name, environment.capacity, environment.reserved
+            status_details.append(
+                (environment.name, environment.capacity, environment.reserved)
             )
+
+    # Defer the Kubernetes status detail updates until after the transaction
+    # commits so the write lock is released first.
+
+    if status_details:
+
+        def _update_status_details():
+            for name, capacity, reserved in status_details:
+                update_environment_status_details(name, capacity, reserved)
+
+        transaction.on_commit(_update_status_details)
 
 
 @background_task
@@ -670,14 +707,27 @@ def replace_workshop_environment(environment):
             environment.workshop_name,
         )
 
-    update_environment_status(environment.name, "Stopping")
     environment.mark_as_stopping()
     report_analytics_event(environment, "Environment/Terminate")
 
+    # Collect the names of the environment and its sessions being stopped so the
+    # Kubernetes status updates can be deferred until after the transaction
+    # commits, keeping the K8s calls out from under the SQLite write lock.
+
+    stopping_environment = environment.name
+    stopping_sessions = []
+
     for session in environment.available_sessions():
-        update_session_status(session.name, "Stopping")
         session.mark_as_stopping()
         report_analytics_event(session, "Session/Terminate")
+        stopping_sessions.append(session.name)
+
+    def _update_stopping_status():
+        update_environment_status(stopping_environment, "Stopping")
+        for name in stopping_sessions:
+            update_session_status(name, "Stopping")
+
+    transaction.on_commit(_update_stopping_status)
 
     # Now schedule creation of the replacement workshop session.
 

--- a/training-portal/src/project/apps/workshops/manager/environments.py
+++ b/training-portal/src/project/apps/workshops/manager/environments.py
@@ -64,39 +64,91 @@ def duration_as_timedelta(duration):
     return timedelta(seconds=max(0, convert_duration_to_seconds(duration)))
 
 
+# Number of attempts made to write a workshop environment status before giving
+# up. The status update is a read-modify-write against the Kubernetes resource
+# using optimistic concurrency, so a concurrent writer can cause the write to be
+# rejected with a 409 conflict. On a conflict we re-read and re-apply; conflicts
+# are transient and almost always clear on the first retry, but the count is
+# bounded so a persistently contended resource cannot spin forever.
+
+ENVIRONMENT_STATUS_UPDATE_ATTEMPTS = 3
+
+
 def update_environment_status(name, phase):
     """Update the status of the Kubernetes resource object for the workshop
     environment.
 
     """
 
-    try:
-        K8SWorkshopEnvironment = pykube.object_factory(
-            api,
-            "training.educates.dev/v1beta1",
-            "WorkshopEnvironment",
-        )
+    K8SWorkshopEnvironment = pykube.object_factory(
+        api,
+        "training.educates.dev/v1beta1",
+        "WorkshopEnvironment",
+    )
 
-        resource = K8SWorkshopEnvironment.objects(api).get(name=name)
+    for _ in range(ENVIRONMENT_STATUS_UPDATE_ATTEMPTS):
+        try:
+            resource = K8SWorkshopEnvironment.objects(api).get(name=name)
 
-        # Can't update status if deployment had stalled due to the workshop
-        # definition not existing.
+            # Can't update status if deployment had stalled due to the workshop
+            # definition not existing.
 
-        if (
-            resource.obj.get("status", {})
-            .get("educates", {})
-            .get("phase")
-        ):
-            resource.obj["status"]["educates"]["phase"] = phase
-            resource.update()
+            if (
+                resource.obj.get("status", {})
+                .get("educates", {})
+                .get("phase")
+            ):
+                resource.obj["status"]["educates"]["phase"] = phase
+                resource.update()
 
-        logger.info("Updated status of workshop environment %s to %s.", name, phase)
+            logger.info(
+                "Updated status of workshop environment %s to %s.", name, phase
+            )
 
-    except pykube.exceptions.ObjectDoesNotExist:
-        pass
+            return
 
-    except pykube.exceptions.PyKubeError:
-        logger.exception("Failed to update status of workshop environment %s.", name)
+        except pykube.exceptions.ObjectDoesNotExist:
+            return
+
+        except pykube.exceptions.HTTPError as exception:
+            # A 409 conflict means the resource was modified between the read and
+            # the write, so the read-modify-write is retried with a fresh read.
+            # Any other HTTP error is not a conflict and is not retried.
+
+            if exception.code != 409:
+                logger.exception(
+                    "Failed to update status of workshop environment %s.", name
+                )
+                return
+
+        except pykube.exceptions.PyKubeError:
+            logger.exception(
+                "Failed to update status of workshop environment %s.", name
+            )
+            return
+
+    logger.warning(
+        "Gave up updating status of workshop environment %s to %s after %d conflicts.",
+        name,
+        phase,
+        ENVIRONMENT_STATUS_UPDATE_ATTEMPTS,
+    )
+
+
+@background_task
+def update_stopping_status(environment_names, session_names):
+    """Mark a batch of workshop environments and sessions as stopping in their
+    Kubernetes status. Run as a separate background task so the status writes
+    happen after the global resources lock held by the caller has been released,
+    keeping the Kubernetes calls out from under the lock.
+
+    """
+
+    for name in environment_names:
+        update_environment_status(name, "Stopping")
+
+    for name in session_names:
+        update_session_status(name, "Stopping")
 
 
 @background_task
@@ -339,25 +391,27 @@ def shutdown_workshop_environments(training_portal, workshops):
                 report_analytics_event(session, "Session/Terminate")
                 stopping_sessions.append(session.name)
 
-    # Defer the Kubernetes status updates until after the transaction commits so
-    # the write lock is released first.
+    # Once the transaction commits, update the Kubernetes status of the stopped
+    # environments and sessions in a separate task so the status writes run after
+    # the global resources lock has been released rather than under it.
 
     if stopping_environments or stopping_sessions:
-
-        def _update_stopping_status():
-            for name in stopping_environments:
-                update_environment_status(name, "Stopping")
-            for name in stopping_sessions:
-                update_session_status(name, "Stopping")
-
-        transaction.on_commit(_update_stopping_status)
+        transaction.on_commit(
+            lambda: update_stopping_status(
+                stopping_environments, stopping_sessions
+            ).schedule()
+        )
 
 
 @background_task
-@resources_lock
 def delete_workshop_environment(environment):
     """Deletes a workshop environment. If this is called when there are still
     workshop sessions, they will be forcibly deleted.
+
+    This runs without the global resources lock. It makes no database changes
+    (the record is marked stopped by the caller before this is scheduled) and
+    only issues a single idempotent Kubernetes delete by name, so it has no
+    shared state to serialise against other work.
 
     """
 
@@ -710,9 +764,10 @@ def replace_workshop_environment(environment):
     environment.mark_as_stopping()
     report_analytics_event(environment, "Environment/Terminate")
 
-    # Collect the names of the environment and its sessions being stopped so the
-    # Kubernetes status updates can be deferred until after the transaction
-    # commits, keeping the K8s calls out from under the SQLite write lock.
+    # Collect the names of the environment and its sessions being stopped. Once
+    # the transaction commits, their Kubernetes status is updated in a separate
+    # task so the status writes run after the global resources lock has been
+    # released rather than under it.
 
     stopping_environment = environment.name
     stopping_sessions = []
@@ -722,12 +777,11 @@ def replace_workshop_environment(environment):
         report_analytics_event(session, "Session/Terminate")
         stopping_sessions.append(session.name)
 
-    def _update_stopping_status():
-        update_environment_status(stopping_environment, "Stopping")
-        for name in stopping_sessions:
-            update_session_status(name, "Stopping")
-
-    transaction.on_commit(_update_stopping_status)
+    transaction.on_commit(
+        lambda: update_stopping_status(
+            [stopping_environment], stopping_sessions
+        ).schedule()
+    )
 
     # Now schedule creation of the replacement workshop session.
 

--- a/training-portal/src/project/apps/workshops/manager/environments.py
+++ b/training-portal/src/project/apps/workshops/manager/environments.py
@@ -524,16 +524,15 @@ def update_workshop_environments(training_portal, workshops):
                 (environment.name, environment.capacity, environment.reserved)
             )
 
-    # Defer the Kubernetes status detail updates until after the transaction
-    # commits so the write lock is released first.
+    # Once the transaction commits, update the capacity and reserved counts in
+    # the Kubernetes status of each environment in a separate task so the status
+    # writes run after the global resources lock has been released rather than
+    # under it.
 
     if status_details:
-
-        def _update_status_details():
-            for name, capacity, reserved in status_details:
-                update_environment_status_details(name, capacity, reserved)
-
-        transaction.on_commit(_update_status_details)
+        transaction.on_commit(
+            lambda: update_environments_status_details(status_details).schedule()
+        )
 
 
 @background_task
@@ -791,37 +790,71 @@ def replace_workshop_environment(environment):
 def update_environment_status_details(name, capacity, reserved):
     """Update the capacity for the workshop environment recorded in the status."""
 
-    try:
-        K8SWorkshopEnvironment = pykube.object_factory(
-            api,
-            "training.educates.dev/v1beta1",
-            "WorkshopEnvironment",
-        )
+    K8SWorkshopEnvironment = pykube.object_factory(
+        api,
+        "training.educates.dev/v1beta1",
+        "WorkshopEnvironment",
+    )
 
-        resource = K8SWorkshopEnvironment.objects(api).get(name=name)
+    for _ in range(ENVIRONMENT_STATUS_UPDATE_ATTEMPTS):
+        try:
+            resource = K8SWorkshopEnvironment.objects(api).get(name=name)
 
-        # The status may not exist as yet if not processed by the operator.
+            # The status may not exist as yet if not processed by the operator.
 
-        status = resource.obj.setdefault("status", {}).setdefault(
-            "educates", {}
-        )
+            status = resource.obj.setdefault("status", {}).setdefault(
+                "educates", {}
+            )
 
-        status["capacity"] = capacity
-        status["reserved"] = reserved
+            status["capacity"] = capacity
+            status["reserved"] = reserved
 
-        resource.update()
+            resource.update()
 
-        logger.info(
-            "Updated status of workshop environment %s with capacity=%s and reserved=%s.",
-            name,
-            capacity,
-            reserved,
-        )
+            logger.info(
+                "Updated status of workshop environment %s with capacity=%s and reserved=%s.",
+                name,
+                capacity,
+                reserved,
+            )
 
-    except pykube.exceptions.ObjectDoesNotExist:
-        pass
+            return
 
-    except pykube.exceptions.PyKubeError:
-        logger.exception(
-            "Failed to update status details of workshop environment %s.", name
-        )
+        except pykube.exceptions.ObjectDoesNotExist:
+            return
+
+        except pykube.exceptions.HTTPError as exception:
+            # A 409 conflict means the resource was modified between the read and
+            # the write, so the read-modify-write is retried with a fresh read.
+            # Any other HTTP error is not a conflict and is not retried.
+
+            if exception.code != 409:
+                logger.exception(
+                    "Failed to update status details of workshop environment %s.", name
+                )
+                return
+
+        except pykube.exceptions.PyKubeError:
+            logger.exception(
+                "Failed to update status details of workshop environment %s.", name
+            )
+            return
+
+    logger.warning(
+        "Gave up updating status details of workshop environment %s after %d conflicts.",
+        name,
+        ENVIRONMENT_STATUS_UPDATE_ATTEMPTS,
+    )
+
+
+@background_task
+def update_environments_status_details(status_details):
+    """Update the capacity and reserved counts recorded in the Kubernetes status
+    of a batch of workshop environments. Run as a separate background task so the
+    status writes happen after the global resources lock held by the caller has
+    been released, keeping the Kubernetes calls out from under the lock.
+
+    """
+
+    for name, capacity, reserved in status_details:
+        update_environment_status_details(name, capacity, reserved)

--- a/training-portal/src/project/apps/workshops/manager/portal.py
+++ b/training-portal/src/project/apps/workshops/manager/portal.py
@@ -15,7 +15,7 @@ from django.conf import settings
 from django.contrib.auth.models import Group
 from django.contrib.auth import get_user_model
 
-from oauth2_provider.models import Application, clear_expired
+from oauth2_provider.models import Application
 
 from ..models import TrainingPortal
 
@@ -319,19 +319,13 @@ def process_training_portal(resource):
 
 
 @background_task(delay=60*60, repeat=True)
-@resources_lock
-@transaction.atomic
 def start_hourly_cleanup_task():
     """Hourly cleanup job."""
 
-    # Clear expired access tokens for OAuth.
-
-    clear_expired()
+    cleanup_old_sessions_and_users().schedule()
 
 
 @background_task(delay=15.0, repeat=True)
-@resources_lock
-@transaction.atomic
 def start_reconciliation_task(name):
     """Periodic reconcilliation task which ensures current deployments of
     workshop environments and workshop sessions matches desired configuration.
@@ -370,8 +364,6 @@ def start_reconciliation_task(name):
     initiate_reserved_sessions(portal).schedule()
 
     purge_expired_workshop_sessions().schedule()
-
-    cleanup_old_sessions_and_users().schedule()
 
 
 @kopf.on.event(

--- a/training-portal/src/project/apps/workshops/manager/sessions.py
+++ b/training-portal/src/project/apps/workshops/manager/sessions.py
@@ -179,49 +179,94 @@ def create_request_resources(session):
     )
 
 
+# Number of attempts made to write a workshop session status before giving up.
+# The status update is a read-modify-write against the Kubernetes resource using
+# optimistic concurrency, so a concurrent writer can cause the write to be
+# rejected with a 409 conflict. On a conflict we re-read and re-apply; conflicts
+# are transient and almost always clear on the first retry, but the count is
+# bounded so a persistently contended resource cannot spin forever.
+
+SESSION_STATUS_UPDATE_ATTEMPTS = 3
+
+
 def update_session_status(name, phase, user=None):
     """Update the status of the Kubernetes resource object for the workshop
     session.
 
     """
 
-    try:
-        K8SWorkshopSession = pykube.object_factory(
-            api, "training.educates.dev/v1beta1", "WorkshopSession"
-        )
+    K8SWorkshopSession = pykube.object_factory(
+        api, "training.educates.dev/v1beta1", "WorkshopSession"
+    )
 
-        resource = K8SWorkshopSession.objects(api).get(name=name)
+    for _ in range(SESSION_STATUS_UPDATE_ATTEMPTS):
+        try:
+            resource = K8SWorkshopSession.objects(api).get(name=name)
 
-        # The status may not exist as yet if not processed by the operator.
-        # In this case fill it in and operator will preserve the value when
-        # sees associated with a training portal.
+            # The status may not exist as yet if not processed by the operator.
+            # In this case fill it in and operator will preserve the value when
+            # sees associated with a training portal.
 
-        status = resource.obj.setdefault("status", {}).setdefault(
-            "educates", {}
-        )
-
-        status["phase"] = phase
-
-        if user:
-            status["user"] = str(user.username)
-
-        resource.update()
-
-        if user:
-            logger.info(
-                "Updated status of workshop session %s to %s for user %s.",
-                name,
-                phase,
-                user.username,
+            status = resource.obj.setdefault("status", {}).setdefault(
+                "educates", {}
             )
-        else:
-            logger.info("Updated status of workshop session %s to %s.", name, phase)
 
-    except pykube.exceptions.ObjectDoesNotExist:
-        pass
+            status["phase"] = phase
 
-    except pykube.exceptions.PyKubeError:
-        logger.exception("Failed to update status of workshop session %s.", name)
+            if user:
+                status["user"] = str(user.username)
+
+            resource.update()
+
+            if user:
+                logger.info(
+                    "Updated status of workshop session %s to %s for user %s.",
+                    name,
+                    phase,
+                    user.username,
+                )
+            else:
+                logger.info("Updated status of workshop session %s to %s.", name, phase)
+
+            return
+
+        except pykube.exceptions.ObjectDoesNotExist:
+            return
+
+        except pykube.exceptions.HTTPError as exception:
+            # A 409 conflict means the resource was modified between the read and
+            # the write, so the read-modify-write is retried with a fresh read.
+            # Any other HTTP error is not a conflict and is not retried.
+
+            if exception.code != 409:
+                logger.exception(
+                    "Failed to update status of workshop session %s.", name
+                )
+                return
+
+        except pykube.exceptions.PyKubeError:
+            logger.exception("Failed to update status of workshop session %s.", name)
+            return
+
+    logger.warning(
+        "Gave up updating status of workshop session %s to %s after %d conflicts.",
+        name,
+        phase,
+        SESSION_STATUS_UPDATE_ATTEMPTS,
+    )
+
+
+@background_task
+def update_sessions_status(names, phase):
+    """Update the Kubernetes status of a batch of workshop sessions. Run as a
+    separate background task so the status writes happen after the global
+    resources lock held by the caller has been released, keeping the Kubernetes
+    calls out from under the lock.
+
+    """
+
+    for name in names:
+        update_session_status(name, phase)
 
 
 def create_workshop_session(session, secret):
@@ -467,6 +512,20 @@ def setup_workshop_session(environment, **session_kwargs):
     return session, secret
 
 
+@background_task
+@resources_lock
+@transaction.atomic
+def create_reserved_session(session, secret):
+    """Deploy a single reserved workshop session in its own task. Scheduling the
+    deployments individually, rather than running them all under the caller's
+    lock, releases the global resources lock between sessions so that session
+    allocation requests are not blocked for the duration of the whole batch.
+
+    """
+
+    create_workshop_session(session, secret)
+
+
 def create_new_session(environment):
     """Setup a record for the workshop session in the database and schedule
     a task to deploy the workshop session in the cluster.
@@ -586,16 +645,14 @@ def terminate_reserved_sessions(portal):
             report_analytics_event(session, "Session/Terminate")
             stopping_names.append(session.name)
 
-    # Defer the Kubernetes status updates until after the transaction commits so
-    # the write lock is released first.
+    # Update the Kubernetes status of the terminated sessions once the
+    # transaction has committed, in a separate task so the status writes run
+    # after the global resources lock has been released rather than under it.
 
     if stopping_names:
-
-        def _update_stopping_status():
-            for name in stopping_names:
-                update_session_status(name, "Stopping")
-
-        transaction.on_commit(_update_stopping_status)
+        transaction.on_commit(
+            lambda: update_sessions_status(stopping_names, "Stopping").schedule()
+        )
 
 
 @background_task
@@ -719,7 +776,10 @@ def initiate_reserved_sessions(portal):
             if spare_capacity <= 0:
                 break
 
-    # Schedule the actual creation of the reserved sessions.
+    # Schedule the actual creation of the reserved sessions once the transaction
+    # has committed. Each session is deployed in its own task so the global
+    # resources lock is released between sessions rather than being held across
+    # the whole batch of Kubernetes calls.
 
     def _schedule_session_creation():
         if sessions:
@@ -730,7 +790,7 @@ def initiate_reserved_sessions(portal):
             )
 
             for session, secret in sessions:
-                create_workshop_session(session, secret)
+                create_reserved_session(session, secret).schedule()
 
     transaction.on_commit(_schedule_session_creation)
 

--- a/training-portal/src/project/apps/workshops/manager/sessions.py
+++ b/training-portal/src/project/apps/workshops/manager/sessions.py
@@ -539,7 +539,12 @@ def terminate_reserved_sessions(portal):
     """
 
     # First kill of reserved sessions for each workshop environment where
-    # they are over what is allowed for that workshop environment.
+    # they are over what is allowed for that workshop environment. Collect the
+    # names of sessions being stopped so the Kubernetes status updates can be
+    # deferred until after the transaction commits, keeping the K8s calls out
+    # from under the SQLite write lock.
+
+    stopping_names = []
 
     for environment in portal.running_environments():
         # If initial number of sessions is greater than reserved sessions then
@@ -561,9 +566,9 @@ def terminate_reserved_sessions(portal):
         for session in islice(environment.available_sessions(), 0, excess):
             logger.info("Terminating reserved workshop session %s.", session.name)
 
-            update_session_status(session.name, "Stopping")
             session.mark_as_stopping()
             report_analytics_event(session, "Session/Terminate")
+            stopping_names.append(session.name)
 
     # Also check that not exceed capacity for the whole training portal. If
     # we are, try and kill of oldest reserved sessions associated with any
@@ -577,9 +582,20 @@ def terminate_reserved_sessions(portal):
         ):
             logger.info("Terminating reserved workshop session %s.", session.name)
 
-            update_session_status(session.name, "Stopping")
             session.mark_as_stopping()
             report_analytics_event(session, "Session/Terminate")
+            stopping_names.append(session.name)
+
+    # Defer the Kubernetes status updates until after the transaction commits so
+    # the write lock is released first.
+
+    if stopping_names:
+
+        def _update_stopping_status():
+            for name in stopping_names:
+                update_session_status(name, "Stopping")
+
+        transaction.on_commit(_update_stopping_status)
 
 
 @background_task
@@ -751,15 +767,30 @@ def allocate_session_for_user(
     session.analytics_url = analytics_url
 
     if token:
-        update_session_status(session.name, "Allocating", user)
         report_analytics_event(session, "Session/Pending")
         session.mark_as_pending(user, token, timeout)
+
+        # Defer the Kubernetes status update until after the transaction has
+        # committed so the SQLite write lock is not held across the K8s call.
+        # Unlike create_session_for_user, this is a real update: the reserved
+        # session's WorkshopSession resource already exists.
+
+        def _schedule_status_update():
+            update_session_status(session.name, "Allocating", user)
+
+        transaction.on_commit(_schedule_status_update)
     else:
-        update_session_status(session.name, "Allocated", user)
         report_analytics_event(session, "Session/Started")
         session.mark_as_running(user)
 
+        # Defer the Kubernetes status update and request resource creation until
+        # after the transaction has committed so the SQLite write lock is not
+        # held across the K8s calls. The status update is folded into the same
+        # post-commit closure to preserve ordering (status set before resources
+        # are created).
+
         def _schedule_resource_creation():
+            update_session_status(session.name, "Allocated", user)
             create_request_resources(session)
 
         transaction.on_commit(_schedule_resource_creation)
@@ -808,11 +839,6 @@ def create_session_for_user(
         session.index_url = index_url
         session.analytics_url = analytics_url
 
-        if token:
-            update_session_status(session.name, "Allocating", user)
-        else:
-            update_session_status(session.name, "Allocated", user)
-
         session.mark_as_pending(user, token, timeout)
 
         if not token:
@@ -840,11 +866,6 @@ def create_session_for_user(
         session.index_url = index_url
         session.analytics_url = analytics_url
 
-        if token:
-            update_session_status(session.name, "Allocating", user)
-        else:
-            update_session_status(session.name, "Allocated", user)
-
         session.mark_as_pending(user, token, timeout)
 
         if not token:
@@ -865,9 +886,20 @@ def create_session_for_user(
 
     if sessions:
         session = sessions[0]
-        update_session_status(session.name, "Stopping")
         session.mark_as_stopping()
         report_analytics_event(session, "Session/Terminate")
+
+        # Defer the Kubernetes status update until after the transaction commits
+        # so the SQLite write lock is released first. Capture the name by value:
+        # the "session" variable is reassigned below to the newly created
+        # session, so the closure must not reference it lazily.
+
+        stopping_name = session.name
+
+        def _update_stopping_status():
+            update_session_status(stopping_name, "Stopping")
+
+        transaction.on_commit(_update_stopping_status)
 
     # Now create the new workshop session for the required workshop
     # environment.
@@ -878,11 +910,6 @@ def create_session_for_user(
 
     session.index_url = index_url
     session.analytics_url = analytics_url
-
-    if token:
-        update_session_status(session.name, "Allocating", user)
-    else:
-        update_session_status(session.name, "Allocated", user)
 
     session.mark_as_pending(user, token, timeout)
 


### PR DESCRIPTION
Release 3.7.3 of the 3.7 support line.

Changes in this release are back ports from 4.0 development (PR #1078) making the training portal more resilient when allocating and managing workshop sessions under load, by moving Kubernetes status updates and session management work off the global lock and out of database transactions.

Verified via the `3.7.3-rc.2` pre-release build and a test install.

After merge, the `3.7.3` final tag will be created on `support/3.7.x`.