### PR TITLE
Add 3.7.3 release notes to develop

### DIFF
--- a/project-docs/index.rst
+++ b/project-docs/index.rst
@@ -100,6 +100,7 @@ Educates
   :caption: Release Notes:
 
   release-notes/version-4.0.0
+  release-notes/version-3.7.3
   release-notes/version-3.7.2
   release-notes/version-3.7.1
   release-notes/version-3.7.0

--- a/project-docs/release-notes/version-3.7.3.md
+++ b/project-docs/release-notes/version-3.7.3.md
@@ -1,6 +1,10 @@
 Version 3.7.3
 =============
 
+This version is a patch release of the 3.7 support line. The changes in this
+release were developed on the main development branch for the upcoming 4.0
+release and have been back ported to the 3.7 support line.
+
 Features Changed
 ----------------
 

--- a/project-docs/release-notes/version-3.7.3.md
+++ b/project-docs/release-notes/version-3.7.3.md
@@ -1,0 +1,15 @@
+Version 3.7.3
+=============
+
+Features Changed
+----------------
+
+* The training portal has been made more resilient when allocating and
+  managing workshop sessions under load. Previously, when many sessions were
+  being requested at the same time, or when the Kubernetes REST API was slow
+  to respond or applying throttling, session allocation could fail or requests
+  could back up, sometimes surfacing as a `database is locked` error or as
+  failed or timed out session requests. Updates the training portal makes to
+  Kubernetes are now performed in a way that no longer blocks other session
+  activity while waiting on the Kubernetes API, reducing failed sessions and
+  improving reliability under high traffic.


### PR DESCRIPTION
Cherry-picks the 3.7.3 release notes from the `release/3.7.3` branch onto `develop`, so the 4.0 documentation lists the 3.7.3 patch release in its release-notes index.

The code changes 3.7.3 shipped were back ports from `develop` (PR #1078) in the first place, so this docs-only cherry-pick replaces the usual full back-merge; merging the release branch itself back would drag 3.7 support-line history into 4.0.