### PR TITLE
Update zot registry in image-cache from 1.4.3 to 2.1.18

### DIFF
--- a/image-cache/Dockerfile
+++ b/image-cache/Dockerfile
@@ -12,9 +12,9 @@ WORKDIR /opt/app-root/src
 
 RUN <<EOF
     set -eo pipefail
-    VERSION=1.4.3
-    CHECKSUM_amd64="f43de78c3b072a18a1e5e8be1bcfe46d8cdf14a4dcf2f0ca5857b440df3e72d8"
-    CHECKSUM_arm64="61371d5605a403326108d5384887dfbcdc27e5907ec264c801b48a63a7811dbb"
+    VERSION=2.1.18
+    CHECKSUM_amd64="a359a0af159db6758b24f8e26d6a244aae95caf3ff382c462875f42d9e082898"
+    CHECKSUM_arm64="0504b0bd926a7ca9dab71055ba0e0bca8ae4bd67159ef4b8ee3855dcc38818c9"
     CHECKSUM=CHECKSUM_${TARGETARCH}
     curl --silent --fail -L -o /usr/bin/zot https://github.com/project-zot/zot/releases/download/v${VERSION}/zot-linux-${TARGETARCH}
     echo "${!CHECKSUM}  /usr/bin/zot" | sha256sum --check --status

--- a/project-docs/custom-resources/workshop-definition.md
+++ b/project-docs/custom-resources/workshop-definition.md
@@ -1377,7 +1377,7 @@ spec:
       memory: 512Mi
 ```
 
-For more details on configuring the synchronization rules for registries see the Zot Registry documentation on [mirroring](https://zotregistry.dev/v1.4.3/articles/mirroring/). Only details under ``registries`` can be supplied, with the exception that providing certificates via ``certDir`` is not supported.
+For more details on configuring the synchronization rules for registries see the Zot Registry documentation on [mirroring](https://zotregistry.dev/v2.1.18/articles/mirroring/). Only details under ``registries`` can be supplied, with the exception that providing certificates via ``certDir`` is not supported.
 
 (injecting-workshop-secrets)=
 Injecting workshop secrets

--- a/project-docs/release-notes/version-4.0.0.md
+++ b/project-docs/release-notes/version-4.0.0.md
@@ -327,6 +327,14 @@ Deprecations
   dependencies which resolve critical vulnerabilities reported against the
   previously bundled versions.
 
+* The Zot Registry used by the OCI image cache for workshop environments has
+  been updated from version 1.4.3 to 2.1.18, resolving a large number of
+  critical and high severity vulnerabilities reported against the old
+  version. The format of the synchronization rules able to be supplied under
+  ``environment.images.registries`` in the workshop definition is unchanged.
+  Any image cache contents from an existing deployment are re-indexed or
+  re-synchronized on demand, so no action is required when upgrading.
+
 * The set of ``kubectl`` versions bundled in the workshop base environment
   image has changed. The 1.31 and 1.32 versions have been dropped and 1.35 and
   1.36 have been added, so the supported range is now 1.33 to 1.36. The

--- a/session-manager/handlers/workshopenvironment.py
+++ b/session-manager/handlers/workshopenvironment.py
@@ -1539,7 +1539,7 @@ def workshop_environment_create(
         }
 
         artifacts_config = {
-            "distSpecVersion": "1.0.1",
+            "distSpecVersion": "1.1.1",
             "storage": {
                 "rootDirectory": "/var/lib/registry",
                 "gc": True,
@@ -1552,7 +1552,9 @@ def workshop_environment_create(
                     "htpasswd": {"path": "/dev/null"},
                 },
                 "accessControl": {
-                    "**": {"anonymousPolicy": ["read"]},
+                    "repositories": {
+                        "**": {"anonymousPolicy": ["read"]},
+                    },
                 },
             },
             "log": {"level": "debug"},


### PR DESCRIPTION
Updates the zot binary bundled in the `image-cache` image from 1.4.3 (mid
2022) to the latest upstream release 2.1.18, resolving 11 critical and 80
high severity Trivy findings reported against the old binary (go-git,
buildkit, go-getter, runc and Go 1.19 stdlib advisories among others).

### Required config change

zot 2.x rejects the access control configuration format generated for the
image cache deployment by the session manager: repository glob patterns
must now be nested under a `repositories` key rather than sitting directly
under `http.accessControl`, and the old format fails config validation at
startup:

```
Error: decoding failed due to the following error(s):
'HTTP.accessControl' has invalid keys: **
```

The config generation in `session-manager/handlers/workshopenvironment.py`
is updated accordingly, and `distSpecVersion` raised to 1.1.1 to match the
OCI distribution spec version implemented by zot 2.x.

### Workshop-facing surface unchanged

The synchronization rules supplied by workshop definitions under
`environment.images.registries` pass through to the zot sync extension
unchanged: 2.x accepts the same `urls`, `onDemand`, `tlsVerify` and
`content` `prefix`/`destination`/`stripPrefix` fields (verified against
the published `zot-schema.json` for 2.1.18).

### Verification

The new image was run with a config generated the same way the session
manager generates it, with a sync rule matching the documented example:

* anonymous `GET /v2/` returns 200 and anonymous push is denied with 401,
* an on-demand sync of an imgpkg artifact from `ghcr.io` through the
  cache succeeds, including the `prefix` to `destination` remapping with
  `stripPrefix`,
* the old flat access control format was confirmed to fail startup on
  2.1.18, and the new nested format was confirmed to fail on nothing.

Rescanning the rebuilt image leaves 0 critical and 3 high findings; the
remainder are an oras-go advisory with no fixed release and a Go stdlib
advisory fixed only in a Go release newer than the one zot 2.1.18 is
built with.

Includes a release-notes entry and updates the zot mirroring
documentation link in the workshop definition docs.