### PR TITLE
Rebuild Kubernetes dashboard backend for the workshop console with patched toolchain and dependencies

### DIFF
--- a/project-docs/release-notes/version-4.0.0.md
+++ b/project-docs/release-notes/version-4.0.0.md
@@ -327,6 +327,14 @@ Deprecations
   dependencies which resolve critical vulnerabilities reported against the
   previously bundled versions.
 
+* The Kubernetes dashboard backend used for the workshop console is now
+  rebuilt from the upstream 2.7.0 sources with a current Go toolchain and
+  patched dependency versions, rather than being copied as a prebuilt binary
+  from the upstream container image. This resolves all critical and the
+  majority of high severity vulnerabilities reported against the previously
+  bundled binary. The dashboard version and its behavior within workshop
+  sessions are unchanged.
+
 * The set of ``kubectl`` versions bundled in the workshop base environment
   image has changed. The 1.31 and 1.32 versions have been dropped and 1.35 and
   1.36 have been added, so the supported range is now 1.33 to 1.36. The

--- a/workshop-images/base-environment/Dockerfile
+++ b/workshop-images/base-environment/Dockerfile
@@ -2,6 +2,36 @@
 
 FROM kubernetesui/dashboard:v2.7.0 AS k8s-console
 
+# The Kubernetes dashboard 2.7.0 image ships a backend binary built with
+# Go 1.19 and vulnerable module versions, and the 2.x series is no longer
+# maintained upstream (3.x/7.x is a multi-container architecture which
+# cannot run as a single process inside the workshop container). Rebuild
+# the same backend from source with a current Go toolchain and patched
+# module versions; the frontend assets are unchanged and still come from
+# the upstream image.
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26 AS k8s-console-build
+
+ARG TARGETARCH
+
+RUN <<EOF
+    set -eo pipefail
+    DASHBOARD_VERSION=2.7.0
+    DASHBOARD_COMMIT=42deb6b32a27296ac47d1f9839a68fab6053e5fc
+    git clone --depth 1 --branch v${DASHBOARD_VERSION} https://github.com/kubernetes/dashboard /dashboard
+    cd /dashboard
+    test "$(git rev-parse HEAD)" = "${DASHBOARD_COMMIT}"
+    go get \
+        github.com/docker/distribution@v2.8.2+incompatible \
+        github.com/moby/spdystream@v0.5.1 \
+        golang.org/x/crypto@v0.54.0 \
+        golang.org/x/net@v0.57.0 \
+        golang.org/x/oauth2@v0.36.0 \
+        golang.org/x/text@v0.40.0
+    go mod tidy
+    CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} \
+        go build -trimpath -ldflags "-s -w" -o /dashboard-backend ./src/app/backend/
+EOF
+
 FROM fedora:44 AS system-base
 
 RUN HOME=/root && \
@@ -100,9 +130,12 @@ FROM system-base AS scratch-image
 
 ARG TARGETARCH
 
-# Kubernetes web console.
+# Kubernetes web console. Frontend assets come from the upstream image;
+# the backend binary is the patched rebuild from the k8s-console-build
+# stage.
 
 COPY --from=k8s-console / /opt/console/
+COPY --from=k8s-console-build /dashboard-backend /opt/console/dashboard
 
 # Miscellaneous tools.
 


### PR DESCRIPTION
The workshop console uses the Kubernetes dashboard 2.7.0 backend binary
copied from the upstream `kubernetesui/dashboard:v2.7.0` image, which was
built in 2022 with Go 1.19 and carries 4 critical and 62 high severity
Trivy findings: all four criticals and 36 highs are Go stdlib advisories,
the remainder sit in old `golang.org/x` module versions,
`docker/distribution` and `moby/spdystream`.

### Why not a version bump

The dashboard 2.x series is no longer maintained upstream, and the
3.x/7.x replacement is a multi-container architecture (api, web, auth,
metrics scraper behind Kong) which cannot run as a single process inside
the workshop container the way `start-console` runs it (`--insecure-port`
behind the workshop gateway, which owns authentication). 2.7.0 is the
last embeddable release.

### What this does instead

A new `k8s-console-build` stage rebuilds the same 2.7.0 backend from
source:

* the `v2.7.0` tag is cloned and pinned by commit hash,
* built with the Go 1.26 toolchain (clears all stdlib advisories),
* the six flagged modules are raised to their fixed versions:
  `docker/distribution` 2.8.2, `moby/spdystream` 0.5.1, `x/crypto`
  0.54.0, `x/net` 0.57.0, `x/oauth2` 0.36.0, `x/text` 0.40.0
  (`docker/distribution` stays on 2.8.2 rather than 2.8.3 because the
  2.8.3 deprecation shim does not compile against the dashboard code),
* the stage cross-compiles from the build platform so multi-arch builds
  do not pay the QEMU cost.

The frontend assets are unchanged and still come from the upstream
image; only the backend binary is replaced.

### Verification

* Trivy on the rebuilt image reports zero critical or high severity
  findings for `opt/console/dashboard` (previously 4 critical, 62 high).
* The exact binary extracted from the rebuilt image was run with the
  same insecure-port arguments `start-console` uses, against a live kind
  cluster: it serves the dashboard UI and API and lists all namespaces.

Includes a release-notes entry.