### PR TITLE
Update session/mirror image registry from distribution 2.8.3 to a patched 3.1.1 build

### DIFF
--- a/docker-registry/Dockerfile
+++ b/docker-registry/Dockerfile
@@ -1,1 +1,32 @@
-FROM registry:2.8.3
+#syntax=docker/dockerfile:1.3-labs
+
+# The upstream registry image ships a binary built with an older Go
+# toolchain and dependency set than the current security fixes require.
+# Rebuild the same distribution release from source (pinned by commit)
+# with a current Go toolchain and the flagged modules raised to their
+# fixed versions, then overlay the binary on the official image so the
+# image configuration and entrypoint stay upstream's.
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26 AS registry-build
+
+ARG TARGETARCH
+
+RUN <<EOF
+    set -eo pipefail
+    DISTRIBUTION_VERSION=3.1.1
+    DISTRIBUTION_COMMIT=9a8d98b679740cd514aa7e7d84d23d442a5ef54c
+    git clone --depth 1 --branch v${DISTRIBUTION_VERSION} https://github.com/distribution/distribution /distribution
+    cd /distribution
+    test "$(git rev-parse HEAD)" = "${DISTRIBUTION_COMMIT}"
+    go get \
+        golang.org/x/crypto@v0.52.0 \
+        golang.org/x/net@v0.55.0 \
+        google.golang.org/grpc@v1.82.1
+    go mod tidy
+    go mod vendor
+    CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} \
+        go build -trimpath -ldflags "-s -w" -o /registry-binary ./cmd/registry
+EOF
+
+FROM registry:3.1.1
+
+COPY --from=registry-build /registry-binary /bin/registry

--- a/project-docs/release-notes/version-4.0.0.md
+++ b/project-docs/release-notes/version-4.0.0.md
@@ -343,6 +343,17 @@ Deprecations
   Any image cache contents from an existing deployment are re-indexed or
   re-synchronized on demand, so no action is required when upgrading.
 
+* The image registry deployed for workshop sessions and for workshop
+  environment image mirrors has been updated from the CNCF Distribution
+  registry version 2.8.3 to 3.1.1, with the registry binary additionally
+  rebuilt against a patched Go toolchain and updated dependencies so that no
+  known critical or high severity vulnerabilities remain. The registry
+  continues to be configured through the same environment variables, so
+  workshop definitions which enable a session image registry or an image
+  mirror require no changes. Note that registry 3.x no longer serves
+  manifests in the legacy Docker schema 1 format, which has been deprecated
+  since Docker 1.10 and does not affect images pushed by current tooling.
+
 * The set of ``kubectl`` versions bundled in the workshop base environment
   image has changed. The 1.31 and 1.32 versions have been dropped and 1.35 and
   1.36 have been added, so the supported range is now 1.33 to 1.36. The


### PR DESCRIPTION
Updates the `docker-registry` image — deployed by the session manager for
per-session image registries and workshop environment image mirrors — from
`registry:2.8.3` (October 2023, Go 1.20) to `registry:3.1.1`, and
additionally rebuilds the registry binary from the pinned v3.1.1 source
with a current Go toolchain and patched dependencies.

### Why the source rebuild

The stock `registry:3.1.1` image clears the old binary's 2 critical and 18
high severity findings but still carries 22 high severity findings of its
own (Go 1.25.9 stdlib plus older `x/crypto`, `x/net` and `grpc` modules,
all with released fixes upstream has not yet shipped). A new
`registry-build` stage clones the `v3.1.1` tag pinned by commit hash,
raises the flagged modules to their fixed versions (`x/crypto` 0.52.0,
`x/net` 0.55.0, `grpc` 1.82.1, re-vendored since distribution vendors its
dependencies), builds with Go 1.26, and overlays the binary on the
official image so the configuration and entrypoint stay upstream's. The
resulting image reports zero critical or high severity findings.

### Compatibility

The session manager configures these registries entirely through
`REGISTRY_*` environment variables (htpasswd auth for session registries,
pull-through proxy settings for mirrors), which behave identically in
3.x — no session manager changes are needed. Registry 3.x drops legacy
Docker schema 1 manifest support, which does not affect images pushed by
current tooling. The CLI-managed local registry already runs
`registry:3`, so this aligns the in-cluster registries with it.

### Verification

Against the rebuilt image, replicating both session-manager deployment
modes:

* htpasswd auth gate: anonymous `/v2/` rejected with 401, authenticated
  accepted with 200,
* authenticated `docker push` and `docker pull` of an image succeed,
* manifest deletion returns 202 with `REGISTRY_STORAGE_DELETE_ENABLED`,
* pull-through proxy mode (`REGISTRY_PROXY_REMOTEURL`) serves proxied
  manifests from an upstream registry,
* Trivy reports 0 critical / 0 high findings (scanned image digest
  verified against the built manifest).

Includes a release-notes entry.