### PR TITLE
Use the stable docker/dockerfile:1 syntax directive in all Dockerfiles

### DIFF
--- a/docker-extension/Dockerfile
+++ b/docker-extension/Dockerfile
@@ -1,3 +1,5 @@
+#syntax=docker/dockerfile:1
+
 ARG REPOSITORY=localhost:5001
 ARG CLI_IMAGE_NAME=educates-cli
 ARG TAG=latest

--- a/docker-registry/Dockerfile
+++ b/docker-registry/Dockerfile
@@ -1,4 +1,4 @@
-#syntax=docker/dockerfile:1.3-labs
+#syntax=docker/dockerfile:1
 
 # The upstream registry image ships a binary built with an older Go
 # toolchain and dependency set than the current security fixes require.

--- a/image-cache/Dockerfile
+++ b/image-cache/Dockerfile
@@ -1,4 +1,4 @@
-#syntax=docker/dockerfile:1.3-labs
+#syntax=docker/dockerfile:1
 
 FROM fedora:44
 

--- a/workshop-images/base-environment/Dockerfile
+++ b/workshop-images/base-environment/Dockerfile
@@ -1,4 +1,4 @@
-#syntax=docker/dockerfile:1.3-labs
+#syntax=docker/dockerfile:1
 
 FROM kubernetesui/dashboard:v2.7.0 AS k8s-console
 
@@ -112,7 +112,7 @@ RUN npm install && \
 # git-serve to the target platform via GOOS/GOARCH below, instead of
 # running the toolchain under QEMU emulation for non-native target
 # architectures during a multiarch build.
-FROM --platform=$BUILDPLATFORM golang:1.26 as builder-image
+FROM --platform=$BUILDPLATFORM golang:1.26 AS builder-image
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/workshop-images/conda-environment/Dockerfile
+++ b/workshop-images/conda-environment/Dockerfile
@@ -1,4 +1,4 @@
-#syntax=docker/dockerfile:1.3-labs
+#syntax=docker/dockerfile:1
 
 ARG IMAGE_REPOSITORY=localhost:5001
 ARG BASE_IMAGE_NAME=educates-base-environment

--- a/workshop-images/jdk11-environment/Dockerfile
+++ b/workshop-images/jdk11-environment/Dockerfile
@@ -1,4 +1,4 @@
-#syntax=docker/dockerfile:1.3-labs
+#syntax=docker/dockerfile:1
 
 ARG IMAGE_REPOSITORY=localhost:5001
 ARG BASE_IMAGE_NAME=educates-base-environment

--- a/workshop-images/jdk17-environment/Dockerfile
+++ b/workshop-images/jdk17-environment/Dockerfile
@@ -1,4 +1,4 @@
-#syntax=docker/dockerfile:1.3-labs
+#syntax=docker/dockerfile:1
 
 ARG IMAGE_REPOSITORY=localhost:5001
 ARG BASE_IMAGE_NAME=educates-base-environment

--- a/workshop-images/jdk21-environment/Dockerfile
+++ b/workshop-images/jdk21-environment/Dockerfile
@@ -1,4 +1,4 @@
-#syntax=docker/dockerfile:1.3-labs
+#syntax=docker/dockerfile:1
 
 ARG IMAGE_REPOSITORY=localhost:5001
 ARG BASE_IMAGE_NAME=educates-base-environment

--- a/workshop-images/jdk8-environment/Dockerfile
+++ b/workshop-images/jdk8-environment/Dockerfile
@@ -1,4 +1,4 @@
-#syntax=docker/dockerfile:1.3-labs
+#syntax=docker/dockerfile:1
 
 ARG IMAGE_REPOSITORY=localhost:5001
 ARG BASE_IMAGE_NAME=educates-base-environment


### PR DESCRIPTION
Follow-up to #1116. Replaces the dated `docker/dockerfile:1.3-labs`
syntax directive with `docker/dockerfile:1` in the eight Dockerfiles that
carried it. Heredoc support graduated from the labs channel to the stable
frontend in dockerfile 1.4, and the floating `1` tag is the
upstream-recommended pin: it always resolves to the latest stable 1.x
frontend, so the files keep receiving parser fixes rather than staying
frozen on a 2021-era labs build.

Also adds the directive to `docker-extension/Dockerfile`, which uses
heredocs but had no syntax directive at all, so its parsing silently
depended on the local builder's embedded frontend being new enough.

The newer frontend's linter surfaced one real inconsistency, a lowercase
`as` in a `base-environment` build stage `FROM`; its casing is fixed to
match.

Verification: all nine Dockerfiles pass `docker buildx build --check`
with no warnings under the new frontend, and the `docker-registry` image
was rebuilt end to end (heredocs exercised through the full buildx
pipeline) as a smoke test.

No release-notes entry: build-internal change with no user-facing effect.