### PR TITLE
Update code-server from 4.125.0 to 4.130.0

### DIFF
--- a/project-docs/release-notes/version-4.0.0.md
+++ b/project-docs/release-notes/version-4.0.0.md
@@ -357,6 +357,11 @@ Deprecations
   dependencies which resolve critical vulnerabilities reported against the
   previously bundled versions.
 
+* The ``code-server`` release which provides the workshop editor has been
+  updated from 4.125.0 to 4.130.0, bringing the embedded VS Code version from
+  1.125.0 to 1.130.0. The update resolves a number of high severity
+  vulnerabilities reported against packages bundled with the editor.
+
 * The Kubernetes dashboard backend used for the workshop console is now
   rebuilt from the upstream 2.7.0 sources with a current Go toolchain and
   patched dependency versions, rather than being copied as a prebuilt binary

--- a/workshop-images/base-environment/Dockerfile
+++ b/workshop-images/base-environment/Dockerfile
@@ -348,9 +348,9 @@ EOF
 # VS Code editor and dashboard extension.
 # Make sure when updating that AI features are disabled and working https://github.com/coder/code-server/issues/7540
 RUN <<EOF
-    CODE_VERSION=4.125.0
-    CHECKSUM_amd64="779f75ae6d5c670fdb710bbdc7bbf66474c37757ac21c14c0f979d9f99c88864"
-    CHECKSUM_arm64="b6e8511a3b82bc8c6d9a01d6cc1c5062ce42268c75f45fba6a89b7bf57849d2c"
+    CODE_VERSION=4.130.0
+    CHECKSUM_amd64="3de23052e34fa705b3817efa66201cbc8d8ba6615b4cd03120c39bfc0ae1b7ab"
+    CHECKSUM_arm64="795366c40d0b32bc6fbbedf8dc992f9767a6125cc6dce965766c5f79e06bb725"
     CHECKSUM=CHECKSUM_${TARGETARCH}
     set -eo pipefail
     mkdir /opt/editor


### PR DESCRIPTION
Updates the `code-server` release providing the workshop editor from 4.125.0 to
4.130.0, moving the embedded VS Code version from 1.125.0 to 1.130.0.

## Verification

Checksums for both architectures were computed from the same download URL the
Dockerfile uses. The base environment image was rebuilt and rescanned with
Trivy:

| | Before | After |
|---|---|---|
| `educates-base-environment` | 6 CRITICAL / 211 HIGH | 6 CRITICAL / **203 HIGH** |

The newer editor bundle carries updated copies of its npm dependencies, which
accounts for the 8 high severity findings cleared. Release notes for 4.126.0
through 4.130.0 record no breaking changes.

## What this does not fix

This upgrade does **not** clear `CVE-2026-59873`, the critical finding against
the editor's bundled `tar`. code-server 4.130.0 ships tar **7.5.17** and the fix
landed in **7.5.19**, so the finding survives the upgrade. The separate copy of
`tar` bundled inside npm is on 7.5.15 and is likewise unaffected.

Both are now blocked on an upstream rebuild rather than a version bump, since
each project is already at its latest release. Worth noting that `tar` has
continued to accumulate advisories since (`GHSA-r292-9mhp-454m` is fixed in
7.5.21), so a single bump is unlikely to clear the package outright.

The upgrade is proposed on its own merits: currency with upstream and 8 fewer
high severity findings.
