### PR TITLE
Patch git-serve dependencies at build time

### DIFF
--- a/workshop-images/base-environment/Dockerfile
+++ b/workshop-images/base-environment/Dockerfile
@@ -119,11 +119,20 @@ ARG TARGETARCH
 
 WORKDIR /app
 
+# git-serve 0.0.5 is the last release its author published, in 2021, so its
+# dependencies are pinned at versions with known vulnerabilities and no newer
+# release will pick up fixes. Bump the flagged modules before building, the
+# same approach the Kubernetes dashboard backend above uses. The release
+# tarball is still checksum pinned, so only the dependency graph moves.
 RUN curl --silent --fail -L -o /tmp/git-serve.tar.gz https://github.com/cirocosta/git-serve/archive/refs/tags/v0.0.5.tar.gz && \
 echo "09cd14a34f17d88cd4f0d2b73e0bbd0bf56984be21bc947f416a7824a709011e /tmp/git-serve.tar.gz" | sha256sum --check --status && \
     tar xvf /tmp/git-serve.tar.gz && \
     cd git-serve-0.0.5 && \
-    go mod download && \
+    go get \
+        github.com/sirupsen/logrus@v1.9.4 \
+        golang.org/x/crypto@v0.54.0 \
+        golang.org/x/net@v0.57.0 && \
+    go mod tidy && \
     CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o git-serve cmd/git-serve/main.go
 
 FROM system-base AS scratch-image


### PR DESCRIPTION
`git-serve` is built from the upstream v0.0.5 release tarball, which its author
published on 2021-11-10 and never followed with another release. Its dependency
graph is therefore pinned at 2021-era versions with known vulnerabilities, and
no upstream release will ever pick up the fixes.

## Change

Bump the flagged modules before compiling, the same approach the Kubernetes
dashboard backend build in this Dockerfile already uses:

| Module | From | To |
|--------|------|----|
| `github.com/sirupsen/logrus` | 1.8.1 | **1.9.4** |
| `golang.org/x/crypto` | `v0.0.0-20210921155107` | **0.54.0** |
| `golang.org/x/net` | (transitive) | **0.57.0** |

The release tarball keeps its sha256 pin, so the source being compiled is
unchanged and only the dependency graph moves.

## Verification

The base environment image was rebuilt and rescanned with Trivy:

| | Before | After |
|---|---|---|
| `git-serve` binary | 15 HIGH | **0** |
| `educates-base-environment` | 203 HIGH | 182 HIGH |

The git-serve binary now reports no findings at CRITICAL or HIGH. The remaining
image-level reduction beyond git-serve's 15 comes from OpenVEX assessments
applied in the same scan.

The five-year-old source compiles cleanly against current `x/crypto`, so no
source patching was needed alongside the dependency bump.
