### PR TITLE
Update code-server from 4.130.0 to 4.131.0 to clear CVE-2026-59873

### DIFF
--- a/project-docs/release-notes/version-4.0.0.md
+++ b/project-docs/release-notes/version-4.0.0.md
@@ -358,9 +358,10 @@ Deprecations
   previously bundled versions.
 
 * The ``code-server`` release which provides the workshop editor has been
-  updated from 4.125.0 to 4.130.0, bringing the embedded VS Code version from
-  1.125.0 to 1.130.0. The update resolves a number of high severity
-  vulnerabilities reported against packages bundled with the editor.
+  updated from 4.125.0 to 4.131.0, bringing the embedded VS Code version from
+  1.125.0 to 1.131.0. The update resolves a critical vulnerability and a number
+  of high severity vulnerabilities reported against packages bundled with the
+  editor.
 
 * The Kubernetes dashboard backend used for the workshop console is now
   rebuilt from the upstream 2.7.0 sources with a current Go toolchain and

--- a/workshop-images/base-environment/Dockerfile
+++ b/workshop-images/base-environment/Dockerfile
@@ -357,9 +357,9 @@ EOF
 # VS Code editor and dashboard extension.
 # Make sure when updating that AI features are disabled and working https://github.com/coder/code-server/issues/7540
 RUN <<EOF
-    CODE_VERSION=4.130.0
-    CHECKSUM_amd64="3de23052e34fa705b3817efa66201cbc8d8ba6615b4cd03120c39bfc0ae1b7ab"
-    CHECKSUM_arm64="795366c40d0b32bc6fbbedf8dc992f9767a6125cc6dce965766c5f79e06bb725"
+    CODE_VERSION=4.131.0
+    CHECKSUM_amd64="f6316f0b14ef5c12ed6e67e0154dd02ccf5e66112064687d7e93c51763105361"
+    CHECKSUM_arm64="4d2a8b2f755446079c4364b18e71c9121181e4e605c6c35939e5f1aac8d1eae8"
     CHECKSUM=CHECKSUM_${TARGETARCH}
     set -eo pipefail
     mkdir /opt/editor


### PR DESCRIPTION
Updates `code-server` from 4.130.0 to 4.131.0, moving the embedded VS Code
version from 1.130.0 to 1.131.0.

This clears `CVE-2026-59873`, the critical finding against the editor's bundled
npm `tar`. 4.131.0 ships **tar 7.5.20**, past the 7.5.19 release which fixes it.

Worth noting explicitly, because the previous attempt did not: the 4.130.0
update in #1126 was made for this same CVE and did **not** fix it, since 4.130.0
ships tar 7.5.17. The bundled version was checked directly before proposing this
one.

## Verification

The base environment image was rebuilt and rescanned with Trivy:

| | Before | After |
|---|---|---|
| `educates-base-environment` | 6 CRITICAL / 182 HIGH | **5 CRITICAL** / 180 HIGH |

Bundled versions in the rebuilt image:

```
code-server  4.131.0
editor tar   7.5.20   <- CVE-2026-59873 cleared
npm tar      7.5.15   <- separate carrier, unchanged
```

The remaining copy of `CVE-2026-59873` is the `tar` bundled inside npm itself,
which is a different carrier and moves only when npm ships a release carrying a
newer tar. The newest Node 24.x (v24.18.1) still ships npm 11.16.0, so there is
nothing to upgrade to for that one yet.

The release note for the editor update is amended in place rather than appended
to, since 4.0.0 is unreleased and the note should describe the version which
actually ships.
