### PR TITLE
Prevent deletion of long-reserved workshop sessions just after allocation

### DIFF
--- a/project-docs/release-notes/version-4.0.0.md
+++ b/project-docs/release-notes/version-4.0.0.md
@@ -462,3 +462,14 @@ Bugs Fixed
   cache. The reconciler now periodically re-validates referenced resources, so
   the status reliably transitions to ``Degraded`` when a referenced
   ``ClusterIssuer`` disappears.
+
+* When reserved workshop sessions were enabled for a workshop environment
+  along with a timeout for deleting orphaned workshop sessions, a workshop
+  session which had sat in reserve for longer than the orphaned timeout could
+  be deleted moments after being allocated to a user. This was because the
+  idle time reported by a workshop session is measured from when the workshop
+  session was created, so the whole period a workshop session spent in
+  reserve was counted as idle time. The reported idle time is now capped at
+  the time which has elapsed since the workshop session was allocated to the
+  user when checking whether a workshop session should be deleted due to
+  being orphaned or inactive.

--- a/training-portal/src/project/apps/workshops/manager/cleanup.py
+++ b/training-portal/src/project/apps/workshops/manager/cleanup.py
@@ -205,6 +205,23 @@ def purge_expired_workshop_sessions():
                         idle_time = timedelta(seconds=response.json()["idle-time"])
                         last_view = timedelta(seconds=response.json()["last-view"])
 
+                        # The workshop session gateway measures idle time from
+                        # when its process started, not from when the session
+                        # was allocated to a user, and only a browser poll
+                        # resets it. A reserved session therefore reports the
+                        # whole time it sat unallocated in reserve as idle
+                        # time, which for a long enough reserved period would
+                        # exceed the inactivity timeout the moment the session
+                        # is activated, before the user's browser has had a
+                        # chance to poll. Clamp both reported values to the
+                        # time the user has actually held the session.
+
+                        if session.started:
+                            allocated_time = now - session.started
+
+                            idle_time = min(idle_time, allocated_time)
+                            last_view = min(last_view, allocated_time)
+
                         if idle_time >= session.environment.orphaned:
                             logger.info(
                                 "Schedule deletion of orphaned workshop session %s after period of %s seconds.",


### PR DESCRIPTION
When reserved workshop sessions are enabled for a workshop environment along
with a timeout for deleting orphaned workshop sessions, a workshop session
which sat in reserve for longer than the orphaned timeout could be deleted
moments after being allocated to a user.

The idle time and last view time reported by a workshop session are measured
from when the workshop session gateway process started, and are only reset by
the user's browser polling the workshop session. Nothing resets them when a
reserved workshop session is allocated to a user, so a session which sat in
reserve for longer than the orphaned timeout already exceeded the deletion
thresholds at the moment it was allocated. Whether it survived was a race
between the first browser poll and the next pass of the periodic orphaned
session check, which runs every fifteen seconds; losing that race meant the
session was deleted within seconds of the user receiving it.

The fix caps both reported values at the time elapsed since the workshop
session was allocated, before comparing them against the deletion thresholds.
Capping rather than skipping the check for recently allocated sessions means
the inactive session check, which uses a multiple of the orphaned timeout as
its threshold, is protected from the stale baseline as well, while genuinely
abandoned workshop sessions are still cleaned up on the same schedule as
before.

The code change is cherry-picked from commit 34e07430 on release/3.8.0,
where the fix has already landed and is included in 3.8.0-rc.6. A release
notes entry for 4.0.0 is included as a separate commit.