### PR TITLE
Update JDK workshop images to the July 2026 Temurin releases

### DIFF
--- a/project-docs/release-notes/version-4.0.0.md
+++ b/project-docs/release-notes/version-4.0.0.md
@@ -403,8 +403,8 @@ Deprecations
 
 * The JDK versions included in the ``jdk8-environment``, ``jdk11-environment``,
   ``jdk17-environment`` and ``jdk21-environment`` workshop base images have
-  been updated to the latest Eclipse Temurin patch releases, being 8u492-b09,
-  11.0.31+11, 17.0.19+10 and 21.0.11+10 respectively. The bundled Maven and
+  been updated to the latest Eclipse Temurin patch releases, being 8u502-b07,
+  11.0.32+9, 17.0.20+8 and 21.0.12+8 respectively. The bundled Maven and
   Gradle versions have also been updated. All four images now include Maven
   3.9.16. The ``jdk8-environment`` and ``jdk11-environment`` images include
   Gradle 8.14.5, the latest version able to run on those JDK versions, while

--- a/workshop-images/jdk11-environment/Dockerfile
+++ b/workshop-images/jdk11-environment/Dockerfile
@@ -15,10 +15,10 @@ RUN <<EOF
     ARCHNAME_amd64=x64
     ARCHNAME_arm64=aarch64
     ARCHNAME=ARCHNAME_${TARGETARCH}
-    CHECKSUM_amd64="1e9de64586b519c0a981319489257cabedd9457599f3823424a87c3158fbe939"
-    CHECKSUM_arm64="257f4d39e060658fc2eb89a803ca43b3f337e64e253f2d94ebae1d85c9ef5f69"
+    CHECKSUM_amd64="5906e0339e9322a688b2375eaf40666e00a16e008b0067b0a9f9e4b6c5033720"
+    CHECKSUM_arm64="66a7d4af3572d920b0f1b01710ffa79888d4ddd1b784632e33a3d711aa7d1e63"
     CHECKSUM=CHECKSUM_${TARGETARCH}
-    curl --fail -sL -o /tmp/jdk11.tar.gz https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.31%2B11/OpenJDK11U-jdk_${!ARCHNAME}_linux_hotspot_11.0.31_11.tar.gz
+    curl --fail -sL -o /tmp/jdk11.tar.gz https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.32%2B9/OpenJDK11U-jdk_${!ARCHNAME}_linux_hotspot_11.0.32_9.tar.gz
     echo "${!CHECKSUM} /tmp/jdk11.tar.gz" | sha256sum --check --status
     tar -C /opt/java --strip-components 1 -zxf /tmp/jdk11.tar.gz
     rm /tmp/jdk11.tar.gz

--- a/workshop-images/jdk17-environment/Dockerfile
+++ b/workshop-images/jdk17-environment/Dockerfile
@@ -15,10 +15,10 @@ RUN <<EOF
     ARCHNAME_amd64=x64
     ARCHNAME_arm64=aarch64
     ARCHNAME=ARCHNAME_${TARGETARCH}
-    CHECKSUM_amd64="d8afc263758141a66e0e3aafc321e783f7016696f4eaea067d340a269037d331"
-    CHECKSUM_arm64="83a52172678ec8975164648654869cb2e71d7c748b47aca94b29bbfa10c18e81"
+    CHECKSUM_amd64="be7668bc030d578b83d6d5ef9221d6d6729bbbca8cf94a7d52e16ac68b5a5a35"
+    CHECKSUM_arm64="d143936f473a4cb24e3b0e247d6d0775769d55ec9775c339540e753059a8d77a"
     CHECKSUM=CHECKSUM_${TARGETARCH}
-    curl --fail -sL -o /tmp/jdk17.tar.gz https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.19%2B10/OpenJDK17U-jdk_${!ARCHNAME}_linux_hotspot_17.0.19_10.tar.gz
+    curl --fail -sL -o /tmp/jdk17.tar.gz https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.20%2B8/OpenJDK17U-jdk_${!ARCHNAME}_linux_hotspot_17.0.20_8.tar.gz
     echo "${!CHECKSUM} /tmp/jdk17.tar.gz" | sha256sum --check --status
     tar -C /opt/java --strip-components 1 -zxf /tmp/jdk17.tar.gz
     rm /tmp/jdk17.tar.gz

--- a/workshop-images/jdk21-environment/Dockerfile
+++ b/workshop-images/jdk21-environment/Dockerfile
@@ -15,10 +15,10 @@ RUN <<EOF
     ARCHNAME_amd64=x64
     ARCHNAME_arm64=aarch64
     ARCHNAME=ARCHNAME_${TARGETARCH}
-    CHECKSUM_amd64="4b2220e232a97997b436ca6ab15cbf70171ecff52958a46159dfa5a8c44ca4de"
-    CHECKSUM_arm64="8d498ec88e1c1989fab95c6784240ab92d011e29c54d20a3f9c324b13476f9ad"
+    CHECKSUM_amd64="e4446ff06a276155697597cc0f1b15da004ff083f4964a35271ecee567177370"
+    CHECKSUM_arm64="eba38e871b02d407897bfe017ea35352dfc1420ef6d2112425b0c67325ca509d"
     CHECKSUM=CHECKSUM_${TARGETARCH}
-    curl --fail -sL -o /tmp/jdk21.tar.gz https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.11%2B10/OpenJDK21U-jdk_${!ARCHNAME}_linux_hotspot_21.0.11_10.tar.gz
+    curl --fail -sL -o /tmp/jdk21.tar.gz https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.12%2B8/OpenJDK21U-jdk_${!ARCHNAME}_linux_hotspot_21.0.12_8.tar.gz
     echo "${!CHECKSUM} /tmp/jdk21.tar.gz" | sha256sum --check --status
     tar -C /opt/java --strip-components 1 -zxf /tmp/jdk21.tar.gz
     rm /tmp/jdk21.tar.gz

--- a/workshop-images/jdk8-environment/Dockerfile
+++ b/workshop-images/jdk8-environment/Dockerfile
@@ -15,10 +15,10 @@ RUN <<EOF
     ARCHNAME_amd64=x64
     ARCHNAME_arm64=aarch64
     ARCHNAME=ARCHNAME_${TARGETARCH}
-    CHECKSUM_amd64="da257f161d7f8c6ca5b0e5d9e4090f65ac28c5e398072e68b8ae87988b1d1a2e"
-    CHECKSUM_arm64="3c2253b986909c20f79d6de7a0cb957f89c243df57615897836046e24d2e5257"
+    CHECKSUM_amd64="b8f5440f64f50193c01f67dacba55c9660caffe13b908baf6bd1955f4dd4c3ea"
+    CHECKSUM_arm64="34912db17786f7144dab274f040a42028e25da6e7a6a09780d7013339a56bdb2"
     CHECKSUM=CHECKSUM_${TARGETARCH}
-    curl --fail -sL -o /tmp/jdk8.tar.gz https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u492-b09/OpenJDK8U-jdk_${!ARCHNAME}_linux_hotspot_8u492b09.tar.gz
+    curl --fail -sL -o /tmp/jdk8.tar.gz https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u502-b07/OpenJDK8U-jdk_${!ARCHNAME}_linux_hotspot_8u502b07.tar.gz
     echo "${!CHECKSUM} /tmp/jdk8.tar.gz" | sha256sum --check --status
     tar -C /opt/java --strip-components 1 -zxf /tmp/jdk8.tar.gz
     rm /tmp/jdk8.tar.gz


### PR DESCRIPTION
Updates the JDK workshop base environments to the latest Eclipse Temurin patch releases:

- `jdk8-environment`: 8u492-b09 → 8u502-b07
- `jdk11-environment`: 11.0.31+11 → 11.0.32+9
- `jdk17-environment`: 17.0.19+10 → 17.0.20+8
- `jdk21-environment`: 21.0.11+10 → 21.0.12+8

Download URLs and the per-architecture SHA256 checksums were updated using the official checksum files published with each Adoptium release, and both `x64` and `aarch64` Linux tarballs were verified to be downloadable.

The bundled Maven and Gradle versions are unchanged: Maven 3.9.16 is still the latest 3.x release, and Gradle 8.14.5 (JDK 8/11) and 9.6.1 (JDK 17/21) are still the latest versions able to run on each JDK.

The existing JDK entry in the 4.0.0 release notes was updated in place with the new version numbers.