### PR TITLE
Strip base-environment test fixtures and update bundled reveal.js versions

### DIFF
--- a/project-docs/custom-resources/workshop-definition.md
+++ b/project-docs/custom-resources/workshop-definition.md
@@ -1946,7 +1946,7 @@ spec:
 
 For slides bundled as a PDF file, add the PDF file to ``workshop/slides`` and then add an ``index.html`` which displays the PDF [embedded](https://stackoverflow.com/questions/291813/recommended-way-to-embed-pdf-in-html) in the page.
 
-To support the use of [reveal.js](https://revealjs.com/), static media assets for that package are already bundled and available for the two major versions (3.X and 4.X).
+To support the use of [reveal.js](https://revealjs.com/), static media assets for that package are already bundled and available for the major versions 4.X, 5.X and 6.X.
 
 To enable and select the version of reveal.js, supply in the workshop definition:
 
@@ -1957,7 +1957,7 @@ spec:
       slides:
         enabled: true
         reveal.js:
-          version: 3.X
+          version: 6.X
 ```
 
 The version can specify the exact version supplied, or a semver style version selector, including range specification.
@@ -1970,7 +1970,7 @@ If you are using reveal.js for the slides and you have history enabled, or are u
 
 When using embedded links to the slides in workshop content, if the workshop content is displayed as part of the dashboard, the slides will be opened in the tab to the right rather than as a separate browser window or tab.
 
-To support the use of [impress.js](https://impress.js.org/), static media assets for that package are already bundled and available for version 1.X.
+To support the use of [impress.js](https://impress.js.org/), static media assets for that package are already bundled and available for versions 1.X and 2.X.
 
 To enable and select the version of impress.js, supply in the workshop definition:
 

--- a/project-docs/release-notes/version-4.0.0.md
+++ b/project-docs/release-notes/version-4.0.0.md
@@ -458,18 +458,6 @@ Deprecations
 Bugs Fixed
 ----------
 
-* The workshop base environment image shipped test fixtures belonging to npm
-  packages bundled for the workshop dashboard gateway and renderer, and to
-  the code editor. One of these fixtures, a ``package.json`` declaring the
-  package ``monorepo-symlink-test`` inside the published tests of the
-  ``resolve`` package, matches a known malicious npm package and is flagged
-  as ``MAL-2022-4691`` by scanners which consult the OpenSSF
-  malicious-packages database, and an editor test fixture carried a private
-  key which is flagged by secret scanners. The test fixture directories are
-  now stripped from the image build, so scans of the published images no
-  longer report these findings. The fixtures were inert test data and were
-  never executed as part of Educates.
-
 * The Contour ingress controller deployed inside a vcluster workshop session
   (when the ``vcluster`` application enables ingress) used hardcoded upstream
   Contour and Envoy image references that were not subject to image relocation
@@ -478,13 +466,6 @@ Bugs Fixed
   first-class entries in the ``imageVersions`` inventory, so they are
   relocatable through the same per-name override mechanism as the other
   platform images and are included in the air-gap image list.
-
-* In Inline mode the ``EducatesClusterConfig`` status could remain ``Ready``
-  after a referenced ``ClusterIssuer`` was deleted, if the deletion event from
-  the cert-manager watch was missed or observed against a momentarily stale
-  cache. The reconciler now periodically re-validates referenced resources, so
-  the status reliably transitions to ``Degraded`` when a referenced
-  ``ClusterIssuer`` disappears.
 
 * When reserved workshop sessions were enabled for a workshop environment
   along with a timeout for deleting orphaned workshop sessions, a workshop

--- a/project-docs/release-notes/version-4.0.0.md
+++ b/project-docs/release-notes/version-4.0.0.md
@@ -239,6 +239,17 @@ Features Changed
   any of these commands from workshop instructions or setup scripts need to
   install them in a custom workshop image, or use an alternative tool.
 
+* The bundled versions of [reveal.js](https://revealjs.com/) used for workshop
+  slides have changed. Version ``6.0.1`` is now bundled alongside ``4.6.1``
+  and ``5.2.1``, and version ``3.9.2`` is no longer included. Workshops which
+  select the reveal.js version through the
+  ``session.applications.slides.reveal.js`` property of the ``Workshop``
+  custom resource using a ``3.X`` selector need to move to ``4.X``, ``5.X``
+  or ``6.X``, and should review their slide decks against the upstream
+  reveal.js upgrade guidance since the markup and plugin APIs changed after
+  the 3.x series. If the requested version cannot be matched against a
+  bundled version the slides are not served for the workshop session.
+
 Deprecations
 ------------
 

--- a/project-docs/release-notes/version-4.0.0.md
+++ b/project-docs/release-notes/version-4.0.0.md
@@ -447,6 +447,18 @@ Deprecations
 Bugs Fixed
 ----------
 
+* The workshop base environment image shipped test fixtures belonging to npm
+  packages bundled for the workshop dashboard gateway and renderer, and to
+  the code editor. One of these fixtures, a ``package.json`` declaring the
+  package ``monorepo-symlink-test`` inside the published tests of the
+  ``resolve`` package, matches a known malicious npm package and is flagged
+  as ``MAL-2022-4691`` by scanners which consult the OpenSSF
+  malicious-packages database, and an editor test fixture carried a private
+  key which is flagged by secret scanners. The test fixture directories are
+  now stripped from the image build, so scans of the published images no
+  longer report these findings. The fixtures were inert test data and were
+  never executed as part of Educates.
+
 * The Contour ingress controller deployed inside a vcluster workshop session
   (when the ``vcluster`` application enables ingress) used hardcoded upstream
   Contour and Envoy image references that were not subject to image relocation

--- a/workshop-images/base-environment/Dockerfile
+++ b/workshop-images/base-environment/Dockerfile
@@ -384,12 +384,7 @@ COPY --from=builder-image /app/git-serve-0.0.5/git-serve /opt/git/bin/git-serve
 
 COPY opt/. /opt/
 
-RUN mkdir -p /opt/slides/reveal.js/3.9.2 && \
-    cd /opt/slides/reveal.js/3.9.2 && \
-    curl -sL -o src.tar.gz https://github.com/hakimel/reveal.js/archive/3.9.2.tar.gz && \
-    tar --strip-components 1 -xf src.tar.gz && \
-    rm src.tar.gz && \
-    mkdir -p /opt/slides/reveal.js/4.6.1 && \
+RUN mkdir -p /opt/slides/reveal.js/4.6.1 && \
     cd /opt/slides/reveal.js/4.6.1 && \
     curl -sL -o src.tar.gz https://github.com/hakimel/reveal.js/archive/4.6.1.tar.gz && \
     tar --strip-components 1 -xf src.tar.gz && \
@@ -397,6 +392,11 @@ RUN mkdir -p /opt/slides/reveal.js/3.9.2 && \
     mkdir -p /opt/slides/reveal.js/5.2.1 && \
     cd /opt/slides/reveal.js/5.2.1 && \
     curl -sL -o src.tar.gz https://github.com/hakimel/reveal.js/archive/5.2.1.tar.gz && \
+    tar --strip-components 1 -xf src.tar.gz && \
+    rm src.tar.gz && \
+    mkdir -p /opt/slides/reveal.js/6.0.1 && \
+    cd /opt/slides/reveal.js/6.0.1 && \
+    curl -sL -o src.tar.gz https://github.com/hakimel/reveal.js/archive/6.0.1.tar.gz && \
     tar --strip-components 1 -xf src.tar.gz && \
     rm src.tar.gz && \
     mkdir -p /opt/slides/impress.js/1.1.0 && \

--- a/workshop-images/base-environment/Dockerfile
+++ b/workshop-images/base-environment/Dockerfile
@@ -368,6 +368,8 @@ RUN <<EOF
     cd /opt/editor
     tar -zxf /tmp/code-server.tar.gz --strip-components=1
     rm /tmp/code-server.tar.gz
+    # Delete server.key from editor test fixtures
+    find /opt/editor/node_modules -type d  \( -name test -o -name tests -o -name __tests__ \) -prune -exec rm -rf {} +
 EOF
 
 COPY --from=vscode-helper --chown=1001:0 /opt/helper/educates-0.0.1.vsix /opt/eduk8s/educates-0.0.1.vsix
@@ -417,13 +419,15 @@ RUN cd /opt/gateway && \
     npm install && \
     npm run compile && \
     npm prune --production && \
-    npm cache clean --force
+    npm cache clean --force && \
+    find node_modules -type d  \( -name test -o -name tests -o -name __tests__ \) -prune -exec rm -rf {} +
 
 RUN cd /opt/renderer && \
     npm install && \
     npm run compile && \
     npm prune --production && \
-    npm cache clean --force
+    npm cache clean --force && \
+    find node_modules -type d  \( -name test -o -name tests -o -name __tests__ \) -prune -exec rm -rf {} +
 
 FROM system-base
 


### PR DESCRIPTION
Two changes to the workshop base environment image, one commit each.

## Strip npm test fixtures from the image

The gateway and renderer `node_modules` trees, and the code editor's bundled
`node_modules`, shipped their dependencies' published test directories. Two
consequences:

- The `resolve` package publishes its tests, which include a fixture
  `package.json` declaring the package name `monorepo-symlink-test`. That
  name matches a known malicious npm package, so scanners consulting the
  OpenSSF malicious-packages database (osv-scanner, Docker Scout) flag the
  image with `MAL-2022-4691`.
- An editor test fixture carried a `server.key` private key flagged by
  secret scanners.

The Dockerfile now removes `test`/`tests`/`__tests__` directories from all
three trees at build time. npm has no install-time mechanism to exclude
files shipped inside a dependency's published tarball (and `resolve`
intentionally publishes its tests), so explicit removal is the fix.

### Verification (rebuild and rescan)

| Check | Before | After |
|---|---|---|
| `resolve/test/resolver/multirepo/package.json` in image | present (gateway + renderer) | absent |
| osv-scanner malware pass (`MAL-` advisories) | `MAL-2022-4691` | none |
| Editor `server.key` secret finding | present | none |

The clean result is detection-backed, not a blind spot: a probe image with
the fixture re-added at the real path was scanned with identical settings
and correctly flagged `MAL-2022-4691`.

## Bundle reveal.js 6.0.1, drop 3.9.2

Bundled reveal.js versions for workshop slides are now `4.6.1`, `5.2.1` and
`6.0.1`. Workshops selecting a `3.X` version through
`session.applications.slides.reveal.js` need to move to a bundled major
version; the gateway resolves the selector with semver `maxSatisfying` over
the bundled directories and does not serve the slides route when nothing
matches. Release notes and the workshop-definition documentation are
updated accordingly (the docs still claimed reveal.js `3.X`/`4.X` and
impress.js `1.X` only).
