### PR TITLE
Strip npm/editor test fixtures from base-environment (3.8 backport)

### DIFF
--- a/project-docs/release-notes/version-3.8.0.md
+++ b/project-docs/release-notes/version-3.8.0.md
@@ -130,6 +130,18 @@ Features Changed
 Bugs Fixed
 ----------
 
+* The workshop base environment image shipped test fixtures belonging to npm
+  packages bundled for the workshop dashboard gateway and renderer, and to
+  the code editor. One of these fixtures, a ``package.json`` declaring the
+  package ``monorepo-symlink-test`` inside the published tests of the
+  ``resolve`` package, matches a known malicious npm package and is flagged
+  as ``MAL-2022-4691`` by scanners which consult the OpenSSF
+  malicious-packages database, and an editor test fixture carried a private
+  key which is flagged by secret scanners. The test fixture directories are
+  now stripped from the image build, so scans of the published images no
+  longer report these findings. The fixtures were inert test data and were
+  never executed as part of Educates.
+
 * When reserved workshop sessions were enabled for a workshop environment
   along with a timeout for deleting orphaned workshop sessions, a workshop
   session which had sat in reserve for longer than the orphaned timeout could

--- a/workshop-images/base-environment/Dockerfile
+++ b/workshop-images/base-environment/Dockerfile
@@ -395,6 +395,8 @@ RUN <<EOF
     cd /opt/editor
     tar -zxf /tmp/code-server.tar.gz --strip-components=1
     rm /tmp/code-server.tar.gz
+    # Delete server.key from editor test fixtures
+    find /opt/editor/node_modules -type d  \( -name test -o -name tests -o -name __tests__ \) -prune -exec rm -rf {} +
 EOF
 
 COPY --from=vscode-helper --chown=1001:0 /opt/helper/educates-0.0.1.vsix /opt/eduk8s/educates-0.0.1.vsix
@@ -444,13 +446,15 @@ RUN cd /opt/gateway && \
     npm install && \
     npm run compile && \
     npm prune --production && \
-    npm cache clean --force
+    npm cache clean --force && \
+    find node_modules -type d  \( -name test -o -name tests -o -name __tests__ \) -prune -exec rm -rf {} +
 
 RUN cd /opt/renderer && \
     npm install && \
     npm run compile && \
     npm prune --production && \
-    npm cache clean --force
+    npm cache clean --force && \
+    find node_modules -type d  \( -name test -o -name tests -o -name __tests__ \) -prune -exec rm -rf {} +
 
 FROM system-base
 


### PR DESCRIPTION
Backport of de88abb9 (merged to `develop` via #1138) onto `release/3.8.0`.

The published `3.8.0-rc.8` images are flagged with `MAL-2022-4691` by scanners that consult the OpenSSF malicious-packages database (osv-scanner, Docker Scout): the `resolve` npm package ships its tests, which contain a fixture `package.json` named `monorepo-symlink-test`, matching a known malicious package. An editor test fixture also carries a `server.key` flagged by secret scanners. Both live in `node_modules` trees in `base-environment` and every workshop environment image derived from it.

This strips `test`/`tests`/`__tests__` directories from the gateway, renderer and editor npm trees at build time. npm has no install-time mechanism to exclude files inside a dependency's published tarball, so explicit removal is the fix.

On `develop` this was verified by rebuild and rescan: fixture paths gone, malware pass clean, and a probe image with the fixture re-added confirmed the scanner detects it at the real path. The cherry-pick applied to the 3.8 Dockerfile without conflicts; only the release-notes entry was relocated to `version-3.8.0.md`.

Contains only this fix plus its release-notes entry.