### PR TITLE
Drop bundled reveal.js 3.9.2, add 6.0.1 (3.8 backport)

### DIFF
--- a/project-docs/custom-resources/workshop-definition.md
+++ b/project-docs/custom-resources/workshop-definition.md
@@ -1946,7 +1946,7 @@ spec:
 
 For slides bundled as a PDF file, add the PDF file to ``workshop/slides`` and then add an ``index.html`` which displays the PDF [embedded](https://stackoverflow.com/questions/291813/recommended-way-to-embed-pdf-in-html) in the page.
 
-To support the use of [reveal.js](https://revealjs.com/), static media assets for that package are already bundled and available for the two major versions (3.X and 4.X).
+To support the use of [reveal.js](https://revealjs.com/), static media assets for that package are already bundled and available for the major versions 4.X, 5.X and 6.X.
 
 To enable and select the version of reveal.js, supply in the workshop definition:
 
@@ -1957,7 +1957,7 @@ spec:
       slides:
         enabled: true
         reveal.js:
-          version: 3.X
+          version: 6.X
 ```
 
 The version can specify the exact version supplied, or a semver style version selector, including range specification.
@@ -1970,7 +1970,7 @@ If you are using reveal.js for the slides and you have history enabled, or are u
 
 When using embedded links to the slides in workshop content, if the workshop content is displayed as part of the dashboard, the slides will be opened in the tab to the right rather than as a separate browser window or tab.
 
-To support the use of [impress.js](https://impress.js.org/), static media assets for that package are already bundled and available for version 1.X.
+To support the use of [impress.js](https://impress.js.org/), static media assets for that package are already bundled and available for versions 1.X and 2.X.
 
 To enable and select the version of impress.js, supply in the workshop definition:
 

--- a/project-docs/release-notes/version-3.8.0.md
+++ b/project-docs/release-notes/version-3.8.0.md
@@ -17,6 +17,21 @@ possible.
 Features Changed
 ----------------
 
+* The bundled versions of [reveal.js](https://revealjs.com/) used for workshop
+  slides have changed. Version ``6.0.1`` is now bundled alongside ``4.6.1``
+  and ``5.2.1``, and version ``3.9.2`` is no longer included. The 3.9.2 copy
+  bundled a ``reveal-js-multiplex`` plugin package which is flagged as
+  malicious (``MAL-2022-5772``) by scanners which consult the OpenSSF
+  malicious-packages database, and the 3.x series of reveal.js has been
+  unmaintained for years. Workshops which select the reveal.js version
+  through the ``session.applications.slides.reveal.js`` property of the
+  ``Workshop`` custom resource using a ``3.X`` selector need to move to
+  ``4.X``, ``5.X`` or ``6.X``, and should review their slide decks against
+  the upstream reveal.js upgrade guidance since the markup and plugin APIs
+  changed after the 3.x series. If the requested version cannot be matched
+  against a bundled version the slides are not served for the workshop
+  session.
+
 * The container base images used for the training portal, session manager,
   secrets manager, lookup service, tunnel manager, image cache and workshop
   base environment have been updated from Fedora 42 to Fedora 44, eliminating

--- a/workshop-images/base-environment/Dockerfile
+++ b/workshop-images/base-environment/Dockerfile
@@ -409,12 +409,7 @@ COPY --from=builder-image /app/git-serve-0.0.5/git-serve /opt/git/bin/git-serve
 
 COPY opt/. /opt/
 
-RUN mkdir -p /opt/slides/reveal.js/3.9.2 && \
-    cd /opt/slides/reveal.js/3.9.2 && \
-    curl -sL -o src.tar.gz https://github.com/hakimel/reveal.js/archive/3.9.2.tar.gz && \
-    tar --strip-components 1 -xf src.tar.gz && \
-    rm src.tar.gz && \
-    mkdir -p /opt/slides/reveal.js/4.6.1 && \
+RUN mkdir -p /opt/slides/reveal.js/4.6.1 && \
     cd /opt/slides/reveal.js/4.6.1 && \
     curl -sL -o src.tar.gz https://github.com/hakimel/reveal.js/archive/4.6.1.tar.gz && \
     tar --strip-components 1 -xf src.tar.gz && \
@@ -422,6 +417,11 @@ RUN mkdir -p /opt/slides/reveal.js/3.9.2 && \
     mkdir -p /opt/slides/reveal.js/5.2.1 && \
     cd /opt/slides/reveal.js/5.2.1 && \
     curl -sL -o src.tar.gz https://github.com/hakimel/reveal.js/archive/5.2.1.tar.gz && \
+    tar --strip-components 1 -xf src.tar.gz && \
+    rm src.tar.gz && \
+    mkdir -p /opt/slides/reveal.js/6.0.1 && \
+    cd /opt/slides/reveal.js/6.0.1 && \
+    curl -sL -o src.tar.gz https://github.com/hakimel/reveal.js/archive/6.0.1.tar.gz && \
     tar --strip-components 1 -xf src.tar.gz && \
     rm src.tar.gz && \
     mkdir -p /opt/slides/impress.js/1.1.0 && \


### PR DESCRIPTION
Backport of 76cf873e (merged to `develop` via #1138) onto `release/3.8.0`.

The reveal.js 3.9.2 copy bundled for workshop slides ships a `reveal-js-multiplex` plugin `package.json` matching a known malicious npm package, flagged as `MAL-2022-5772` in the published `3.8.0-rc.8` base-environment and workshop environment images by scanners consulting the OpenSSF malicious-packages database. The 3.x series of reveal.js is long unmaintained, so there is no fixed 3.x version to move to. This drops 3.9.2 and adds 6.0.1 alongside the existing 4.6.1 and 5.2.1, updating the workshop-definition documentation and release notes to match.

**Behaviour note for the 3.x line:** workshops selecting `session.applications.slides.reveal.js` with a `3.X` selector stop having slides served (the gateway resolves the selector with semver `maxSatisfying` over the bundled directories and serves nothing on no match). That is a deliberate removal within a maintained line, justified by the malicious-package flag; the release-notes entry calls it out and points at the upstream upgrade guidance.

On `develop` this was verified by rebuild and rescan of the base and workshop environment images: `MAL-2022-5772` gone, `/opt/slides/reveal.js` carries `4.6.1`/`5.2.1`/`6.0.1` only. The cherry-pick applied cleanly to 3.8 (which bundles the same three prior versions and both impress.js versions); only the release-notes entry was relocated to `version-3.8.0.md`.

Contains only this change plus its documentation and release-notes entry.