### PR TITLE
Update zot registry from 1.4.3 to 2.1.18 (3.8 backport)

### DIFF
--- a/image-cache/Dockerfile
+++ b/image-cache/Dockerfile
@@ -12,9 +12,9 @@ WORKDIR /opt/app-root/src
 
 RUN <<EOF
     set -eo pipefail
-    VERSION=1.4.3
-    CHECKSUM_amd64="f43de78c3b072a18a1e5e8be1bcfe46d8cdf14a4dcf2f0ca5857b440df3e72d8"
-    CHECKSUM_arm64="61371d5605a403326108d5384887dfbcdc27e5907ec264c801b48a63a7811dbb"
+    VERSION=2.1.18
+    CHECKSUM_amd64="a359a0af159db6758b24f8e26d6a244aae95caf3ff382c462875f42d9e082898"
+    CHECKSUM_arm64="0504b0bd926a7ca9dab71055ba0e0bca8ae4bd67159ef4b8ee3855dcc38818c9"
     CHECKSUM=CHECKSUM_${TARGETARCH}
     curl --silent --fail -L -o /usr/bin/zot https://github.com/project-zot/zot/releases/download/v${VERSION}/zot-linux-${TARGETARCH}
     echo "${!CHECKSUM}  /usr/bin/zot" | sha256sum --check --status

--- a/project-docs/custom-resources/workshop-definition.md
+++ b/project-docs/custom-resources/workshop-definition.md
@@ -1377,7 +1377,7 @@ spec:
       memory: 512Mi
 ```
 
-For more details on configuring the synchronization rules for registries see the Zot Registry documentation on [mirroring](https://zotregistry.dev/v1.4.3/articles/mirroring/). Only details under ``registries`` can be supplied, with the exception that providing certificates via ``certDir`` is not supported.
+For more details on configuring the synchronization rules for registries see the Zot Registry documentation on [mirroring](https://zotregistry.dev/v2.1.18/articles/mirroring/). Only details under ``registries`` can be supplied, with the exception that providing certificates via ``certDir`` is not supported.
 
 (injecting-workshop-secrets)=
 Injecting workshop secrets

--- a/project-docs/release-notes/version-3.8.0.md
+++ b/project-docs/release-notes/version-3.8.0.md
@@ -17,6 +17,14 @@ possible.
 Features Changed
 ----------------
 
+* The Zot Registry used by the OCI image cache for workshop environments has
+  been updated from version 1.4.3 to 2.1.18, resolving a large number of
+  critical and high severity vulnerabilities reported against the old
+  version. The format of the synchronization rules able to be supplied under
+  ``environment.images.registries`` in the workshop definition is unchanged.
+  Any image cache contents from an existing deployment are re-indexed or
+  re-synchronized on demand, so no action is required when upgrading.
+
 * The container base images used for the training portal, session manager,
   secrets manager, lookup service, tunnel manager, image cache and workshop
   base environment have been updated from Fedora 42 to Fedora 44, eliminating

--- a/session-manager/handlers/workshopenvironment.py
+++ b/session-manager/handlers/workshopenvironment.py
@@ -1539,7 +1539,7 @@ def workshop_environment_create(
         }
 
         artifacts_config = {
-            "distSpecVersion": "1.0.1",
+            "distSpecVersion": "1.1.1",
             "storage": {
                 "rootDirectory": "/var/lib/registry",
                 "gc": True,
@@ -1552,7 +1552,9 @@ def workshop_environment_create(
                     "htpasswd": {"path": "/dev/null"},
                 },
                 "accessControl": {
-                    "**": {"anonymousPolicy": ["read"]},
+                    "repositories": {
+                        "**": {"anonymousPolicy": ["read"]},
+                    },
                 },
             },
             "log": {"level": "debug"},


### PR DESCRIPTION
Backport of 278b9a93 onto `release/3.8.0`.

The zot registry bundled in the `image-cache` image accounts for 11 CRITICAL / 84 HIGH findings in the published `3.8.0-rc.8` scan; 1.4.3 dates from 2022 and upstream ships no fixes for that line. This updates to 2.1.18 with matching checksums for both architectures.

The functional part of the change is the zot 2.x configuration schema in the session manager (`workshopenvironment.py`): `distSpecVersion` moves to 1.1.1 and the access-control policy nests under `repositories`. The synchronization-rules format workshop authors supply under `environment.images.registries` is unchanged, and cache contents re-index on demand, so upgrading needs no action.

The cherry-pick applied to 3.8 without conflicts (the session manager's zot config is identical in this region); verified on `develop` by rebuild and rescan of `image-cache` (0 CRITICAL / 4 HIGH remain against current zot, all unfixed upstream). The handler compiles; the release-notes entry was relocated to `version-3.8.0.md`.

Contains only this update plus its documentation link fix and release-notes entry.