### PR TITLE
Update distribution registry from 2.8.3 to patched 3.1.1 build (3.8 backport)

### DIFF
--- a/docker-registry/Dockerfile
+++ b/docker-registry/Dockerfile
@@ -1,1 +1,32 @@
-FROM registry:2.8.3
+#syntax=docker/dockerfile:1.3-labs
+
+# The upstream registry image ships a binary built with an older Go
+# toolchain and dependency set than the current security fixes require.
+# Rebuild the same distribution release from source (pinned by commit)
+# with a current Go toolchain and the flagged modules raised to their
+# fixed versions, then overlay the binary on the official image so the
+# image configuration and entrypoint stay upstream's.
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26 AS registry-build
+
+ARG TARGETARCH
+
+RUN <<EOF
+    set -eo pipefail
+    DISTRIBUTION_VERSION=3.1.1
+    DISTRIBUTION_COMMIT=9a8d98b679740cd514aa7e7d84d23d442a5ef54c
+    git clone --depth 1 --branch v${DISTRIBUTION_VERSION} https://github.com/distribution/distribution /distribution
+    cd /distribution
+    test "$(git rev-parse HEAD)" = "${DISTRIBUTION_COMMIT}"
+    go get \
+        golang.org/x/crypto@v0.52.0 \
+        golang.org/x/net@v0.55.0 \
+        google.golang.org/grpc@v1.82.1
+    go mod tidy
+    go mod vendor
+    CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} \
+        go build -trimpath -ldflags "-s -w" -o /registry-binary ./cmd/registry
+EOF
+
+FROM registry:3.1.1
+
+COPY --from=registry-build /registry-binary /bin/registry

--- a/project-docs/release-notes/version-3.8.0.md
+++ b/project-docs/release-notes/version-3.8.0.md
@@ -17,6 +17,17 @@ possible.
 Features Changed
 ----------------
 
+* The image registry deployed for workshop sessions and for workshop
+  environment image mirrors has been updated from the CNCF Distribution
+  registry version 2.8.3 to 3.1.1, with the registry binary additionally
+  rebuilt against a patched Go toolchain and updated dependencies so that no
+  known critical or high severity vulnerabilities remain. The registry
+  continues to be configured through the same environment variables, so
+  workshop definitions which enable a session image registry or an image
+  mirror require no changes. Note that registry 3.x no longer serves
+  manifests in the legacy Docker schema 1 format, which has been deprecated
+  since Docker 1.10 and does not affect images pushed by current tooling.
+
 * The container base images used for the training portal, session manager,
   secrets manager, lookup service, tunnel manager, image cache and workshop
   base environment have been updated from Fedora 42 to Fedora 44, eliminating


### PR DESCRIPTION
Backport of 1396faeea (merged to `develop` via #1116) onto `release/3.8.0`.

The `docker-registry` image used for workshop session registries and image mirrors was `FROM registry:2.8.3`, which accounts for 2 CRITICAL / 18 HIGH findings in the published `3.8.0-rc.8` scan. This moves to distribution 3.1.1 and additionally rebuilds the registry binary from the commit-pinned source with a current Go toolchain and the flagged modules raised to fixed versions, overlaying the binary on the official image so configuration and entrypoint stay upstream's.

Registry configuration is unchanged (same environment variables), so workshop definitions need no changes; registry 3.x drops only the legacy Docker schema 1 manifest format, deprecated since Docker 1.10.

The cherry-pick applied to 3.8 without conflicts (3.8's Dockerfile was the same single `FROM registry:2.8.3` line the commit replaced); verified on `develop` by rebuild and rescan (registry-binary findings gone). The release-notes entry was relocated to `version-3.8.0.md`.

Contains only this change plus its release-notes entry.