### PR TITLE
Patch git-serve dependencies at build time (3.8 backport)

### DIFF
--- a/project-docs/release-notes/version-3.8.0.md
+++ b/project-docs/release-notes/version-3.8.0.md
@@ -17,6 +17,14 @@ possible.
 Features Changed
 ----------------
 
+* The ``git-serve`` program bundled in the workshop base image, which
+  provides the per-session Git server, is now built with patched versions of
+  its Go module dependencies. The 0.0.5 release it is built from is the last
+  its author published, so the dependency versions it pins carry known
+  vulnerabilities and no newer release exists to pick up fixes. The flagged
+  modules are raised to fixed versions at build time; the behavior of the
+  per-session Git server is unchanged.
+
 * The container base images used for the training portal, session manager,
   secrets manager, lookup service, tunnel manager, image cache and workshop
   base environment have been updated from Fedora 42 to Fedora 44, eliminating

--- a/workshop-images/base-environment/Dockerfile
+++ b/workshop-images/base-environment/Dockerfile
@@ -82,11 +82,20 @@ FROM golang:1.26 as builder-image
 
 WORKDIR /app
 
+# git-serve 0.0.5 is the last release its author published, in 2021, so its
+# dependencies are pinned at versions with known vulnerabilities and no newer
+# release will pick up fixes. Bump the flagged modules before building. The
+# release tarball is still checksum pinned, so only the dependency graph
+# moves.
 RUN curl --silent --fail -L -o /tmp/git-serve.tar.gz https://github.com/cirocosta/git-serve/archive/refs/tags/v0.0.5.tar.gz && \
 echo "09cd14a34f17d88cd4f0d2b73e0bbd0bf56984be21bc947f416a7824a709011e /tmp/git-serve.tar.gz" | sha256sum --check --status && \
     tar xvf /tmp/git-serve.tar.gz && \
     cd git-serve-0.0.5 && \
-    go mod download && \
+    go get \
+        github.com/sirupsen/logrus@v1.9.4 \
+        golang.org/x/crypto@v0.54.0 \
+        golang.org/x/net@v0.57.0 && \
+    go mod tidy && \
     go build -o git-serve cmd/git-serve/main.go
 
 FROM system-base AS scratch-image


### PR DESCRIPTION
Backport of 47adc5775 (merged to `develop` via #1129) onto `release/3.8.0`.

`git-serve` 0.0.5 is the last release its author published (2021), so its pinned Go modules carry known vulnerabilities (15 HIGH findings against the binary in earlier scans of the develop line) with no upstream release to move to. This raises the flagged modules (`logrus`, `x/crypto`, `x/net`) to fixed versions at build time before compiling; the release tarball itself stays checksum pinned, so only the dependency graph moves.

Cherry-pick adaptation for 3.8: the develop commit's build line uses `CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH}` because develop's builder stage is pinned to the build platform and cross-compiles; 3.8's builder stage builds natively per target platform and declares no such ARGs, so the resolution keeps 3.8's plain `go build` line and takes only the dependency bumps (`go mod download` is superseded by `go get` + `go mod tidy`). A release-notes entry was added to `version-3.8.0.md` (the develop commit had none, being a pure dependency patch).

Verified on `develop` by rebuild and rescan: the git-serve item dropped from the triage checklist entirely.

Contains only this change plus its release-notes entry.