### PR TITLE
Update sample lab-k8s-fundamentals workshop version to 9.0.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -324,8 +324,8 @@ restart-training-platform: ## Restart the deployed platform components
 	kubectl rollout restart deployment/session-manager -n educates
 
 deploy-workshop: ## Deploy the lab-k8s-fundamentals sample workshop
-	kubectl apply -f https://github.com/educates/lab-k8s-fundamentals/releases/download/8.4/workshop.yaml
-	kubectl apply -f https://github.com/educates/lab-k8s-fundamentals/releases/download/8.4/trainingportal.yaml
+	kubectl apply -f https://github.com/educates/lab-k8s-fundamentals/releases/download/9.0/workshop.yaml
+	kubectl apply -f https://github.com/educates/lab-k8s-fundamentals/releases/download/9.0/trainingportal.yaml
 	STATUS=1; ATTEMPTS=0; ROLLOUT_STATUS_CMD="kubectl rollout status deployment/training-portal -n lab-k8s-fundamentals-ui"; until [ $$STATUS -eq 0 ] || $$ROLLOUT_STATUS_CMD || [ $$ATTEMPTS -eq 5 ]; do sleep 5; $$ROLLOUT_STATUS_CMD; STATUS=$$?; ATTEMPTS=$$((ATTEMPTS + 1)); done
 
 delete-workshop:


### PR DESCRIPTION
Updates the `deploy-workshop` convenience target in the root Makefile to deploy the 9.0 release of the lab-k8s-fundamentals sample workshop (previously 8.4). Verified the 9.0 release exists with both `workshop.yaml` and `trainingportal.yaml` assets.