### PR TITLE
Update conda environment image to miniconda 26.5.3-2 (Python 3.14)

### DIFF
--- a/project-docs/release-notes/version-4.0.0.md
+++ b/project-docs/release-notes/version-4.0.0.md
@@ -433,6 +433,15 @@ Deprecations
   ``--overwrite`` option to ``gradle init`` or create the project in a new
   empty subdirectory.
 
+* The ``conda-environment`` workshop base image has been updated to use
+  Miniconda 26.5.3-2, with the conda environment it provides now based on
+  Python 3.14 rather than Python 3.13. The bundled ``notebook`` and
+  ``jupyterlab`` packages have also been updated, to versions 7.6.1 and 4.6.2
+  respectively. Workshops which install additional conda or pip packages into
+  the default conda environment should be verified against the newer Python
+  version in case any of the packages they depend on do not yet support
+  Python 3.14.
+
 * The ``vcluster`` software used by the ``vcluster`` workshop application has
   been updated from 0.30.2 to 0.35.2, and the set of Kubernetes versions the
   virtual cluster can provision has been aligned with the versions supported

--- a/workshop-images/conda-environment/Dockerfile
+++ b/workshop-images/conda-environment/Dockerfile
@@ -11,8 +11,8 @@ ARG TARGETARCH
 ENV CONDA_DIR=/opt/conda \
     PATH=/opt/conda/bin:$PATH
 
-ENV MINICONDA_VERSION=25.5.1-1 \
-    CONDA_VERSION=25.5.1
+ENV MINICONDA_VERSION=26.5.3-2 \
+    CONDA_VERSION=26.5.3
 
 RUN <<EOF
     set -x
@@ -20,12 +20,12 @@ RUN <<EOF
     ARCHNAME_amd64=x86_64
     ARCHNAME_arm64=aarch64
     ARCHNAME=ARCHNAME_${TARGETARCH}
-    CHECKSUM_amd64="612af113b49db0368e2be41ac4d51b7088eebd5f31daeeb89f23fff8f920db58"
-    CHECKSUM_arm64="b7d611dcaa638efd700a4a4eb24fbcb9f7b94cc1773d7c655959c330d0b68e16"
+    CHECKSUM_amd64="80bc27f13c4de90f10e387aa45e864de4f0860692c1221aef5900009a2b55302"
+    CHECKSUM_arm64="999e8761f4dc74fb8d0dc9f74d5374f6708ff81eebbb0af677a4d5307d38b2e5"
     CHECKSUM=CHECKSUM_${TARGETARCH}
     mkdir -p $CONDA_DIR
     cd /tmp
-    curl --fail --silent -L -o install-miniconda.sh "https://repo.anaconda.com/miniconda/Miniconda3-py313_${MINICONDA_VERSION}-Linux-${!ARCHNAME}.sh"
+    curl --fail --silent -L -o install-miniconda.sh "https://repo.anaconda.com/miniconda/Miniconda3-py314_${MINICONDA_VERSION}-Linux-${!ARCHNAME}.sh"
     echo "${!CHECKSUM} install-miniconda.sh" | sha256sum --check --status
     /bin/bash install-miniconda.sh -f -b -p $CONDA_DIR
     rm install-miniconda.sh
@@ -52,7 +52,7 @@ RUN <<EOF
     set -eo pipefail
     conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main
     conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r
-    conda install --quiet --yes 'notebook=7.4.5' 'jupyterlab=4.4.6'
+    conda install --quiet --yes 'notebook=7.6.1' 'jupyterlab=4.6.2'
     conda clean --all -f -y
     npm cache clean --force
     rm -rf $CONDA_DIR/share/jupyter/lab/staging


### PR DESCRIPTION
Updates the conda-environment workshop image:

* Miniconda installer 25.5.1-1 -> 26.5.3-2, switching from the `py313` to the `py314` variant, so the base conda environment now runs Python 3.14. SHA256 checksums for both amd64 and arm64 installers verified against repo.anaconda.com.
* `notebook` 7.4.5 -> 7.6.1 and `jupyterlab` 4.4.6 -> 4.6.2 (current conda-forge latest), keeping the Jupyter stack compatible with the newer base Python.

Includes a 4.0.0 release notes entry as a separate commit so the image change can be backported to the 3.8 line on its own.

Image build and JupyterLab operation were tested against the 3.8.0 release line, where the Dockerfile is identical apart from the `#syntax` header.