### PR TITLE
Skip renderer readiness check for non-classic local renderer

### DIFF
--- a/workshop-images/base-environment/opt/gateway/src/backend/modules/workshop.ts
+++ b/workshop-images/base-environment/opt/gateway/src/backend/modules/workshop.ts
@@ -33,6 +33,15 @@ export function setup_workshop(app: express.Application) {
         if (!config.enable_workshop)
             return res.redirect(workshop_url)
 
+        // The local renderer process only runs for the classic renderer type.
+        // For any other local renderer the content is rendered up front and
+        // served statically below, so there is no renderer to wait on and the
+        // check would always fail. Mirrors the condition used when setting up
+        // serving further down.
+
+        if (config.workshop_renderer == "local" && config.local_renderer_type != "classic")
+            return res.redirect(workshop_url)
+
         // Check whether the internal workshop content renderer is ready.
 
         let url = 'http://127.0.0.1:' + config.workshop_port


### PR DESCRIPTION
## What

`/workshop/.redirect-when-workshop-is-ready` returns early for the `remote` and `static` renderers, and when the workshop application is disabled — but not for a `local` renderer whose type is not `classic`.

For those, `start-container` sets `ENABLE_WORKSHOP_PROCESS=false` (the `workshop` supervisor program's `autostart`), so the renderer process never starts and nothing listens on the workshop port. The readiness check therefore cannot succeed: axios-retry makes its three attempts at 500ms, 1000ms and 1500ms, and the handler then redirects to **the same URL it would have redirected to on success**. The wait changes no outcome.

## Impact

It is paid on every dashboard load, not once per session. The workshop panel iframe uses this URL as its initial `src` (`workshop-panel-content.pug`), and the startup cover panel is hidden on the window `load` event, which waits for that iframe — so the delay sits in front of the whole dashboard, not just the workshop panel.

Measured against a hugo workshop on 3.8.0-rc.6, from the gateway's own access log:

```
GET /workshop/.redirect-when-workshop-is-ready
  92 of 92 loads → 302
  min 3008ms | median 3018ms | max 3076ms
```

which matches the retry schedule exactly (500 + 1000 + 1500 = 3000ms plus a few ms of work). Distinct session pods logging `Error with workshop backend` matched distinct learner sessions 1:1 on three consecutive days.

## The change

Adds the condition already used when setting up serving further down the same function, where a `local` renderer that is not `classic` falls through to serving pre-rendered content with `express.static`. So the guard list for the readiness check now agrees with the serving logic.

## Testing

`npx tsc --noEmit` is clean in `workshop-images/base-environment/opt/gateway`.

I have not built or run a patched base-environment image — the evidence above is black-box measurement of the released 3.8.0-rc.6 gateway on our own cluster, plus reading the deployed `workshop.js`. Happy to adjust if you would rather solve it differently; not rendering the probe iframe at all for pre-rendered content would also work, and you would know better which you prefer.

For context, we are working around it locally with a small listener on the workshop port, so nothing here is urgent for us.
