### PR TITLE
fix(installer): stop phantom educates-config secret versions on every reconcile

### DIFF
--- a/carvel-packages/installer/bundle/config/kapp/kapp-config-secrets.yaml
+++ b/carvel-packages/installer/bundle/config/kapp/kapp-config-secrets.yaml
@@ -7,17 +7,20 @@ rebaseRules:
     sources: [existing, new]
     resourceMatchers:
       - apiVersionKindMatcher: { apiVersion: v1, kind: Secret }
-  # - paths:
-  #     - [data]
-  #     - [metadata,annotations,"kubernetes.io/service-account.uid"]
-  #     - [metadata,annotations,"kubernetes.io/service-account.name"]
-  #     - [type]
-  #   type: copy
-  #   sources: [existing, new]
-  #   resourceMatchers:
-  #     - andMatcher:
-  #         matchers:
-  #           - apiVersionKindMatcher: { apiVersion: v1, kind: Secret }
-  #           - hasAnnotationMatcher:
-  #               keys: 
-  #                 - "kubernetes.io/service-account.name"
+  # Service-account token Secrets have their data and uid annotation populated
+  # by the token controller, so the rendered resource never matches live state.
+  # Copy those fields from the live resource to avoid re-applying the Secret on
+  # every reconcile.
+  - paths:
+      - [data]
+      - [metadata, annotations, "kubernetes.io/service-account.uid"]
+      - [metadata, annotations, "kubernetes.io/service-account.name"]
+    type: copy
+    sources: [existing, new]
+    resourceMatchers:
+      - andMatcher:
+          matchers:
+            - apiVersionKindMatcher: { apiVersion: v1, kind: Secret }
+            - hasAnnotationMatcher:
+                keys:
+                  - "kubernetes.io/service-account.name"

--- a/carvel-packages/installer/bundle/config/ytt/_ytt_lib/packages/educates/06-secrets.yaml
+++ b/carvel-packages/installer/bundle/config/ytt/_ytt_lib/packages/educates/06-secrets.yaml
@@ -15,7 +15,12 @@ metadata:
   annotations:
     kapp.k14s.io/versioned: ""
     kapp.k14s.io/num-versions: "5"
-    kapp.k14s.io/disable-original: ""
+#! stringData (not data) is deliberate: the kbld search rules in
+#! kbld/kbld-bundle.yaml rewrite image references inside this config and
+#! cannot see into base64-encoded values. Change detection for this versioned
+#! secret relies on the kapp.k14s.io/original annotation being kept (see
+#! functions/kapp-annotations.lib.yaml), as the API server converts stringData
+#! to data on the live object so it can never match the rendered resource.
 stringData:
   educates-operator-config.yaml: #@ yaml.encode(data.values)
   kyverno-policies.yaml: #@ yaml.encode(kyverno_policies)

--- a/carvel-packages/installer/bundle/config/ytt/_ytt_lib/packages/external-dns/overlays/overlay-azure.yaml
+++ b/carvel-packages/installer/bundle/config/ytt/_ytt_lib/packages/external-dns/overlays/overlay-azure.yaml
@@ -1,6 +1,7 @@
 #@ load("@ytt:overlay", "overlay")
 #@ load("@ytt:data", "data")
 #@ load("@ytt:json", "json")
+#@ load("@ytt:base64", "base64")
 #@ load("@ytt:struct", "struct")
 #@ load("@ytt:assert", "assert")
 
@@ -36,8 +37,8 @@ metadata:
   name: azure-config-file
   namespace: #@ data.values.namespace
 type: Opaque
-stringData:
-  azure.json: #@ json.encode(json_data)
+data:
+  azure.json: #@ base64.encode(json.encode(json_data))
 
 #@overlay/match by=overlay.subset({"kind":"Deployment", "metadata":{"name":"external-dns"}})
 #@overlay/match-child-defaults missing_ok=True

--- a/carvel-packages/installer/bundle/config/ytt/config.yaml
+++ b/carvel-packages/installer/bundle/config/ytt/config.yaml
@@ -4,7 +4,7 @@
 #@ load("@ytt:overlay", "overlay")
 #@ load("@ytt:struct", "struct")
 #@ load("@ytt:yaml", "yaml")
-#@ load("functions/kapp-annotations.lib.yaml", "addKappAnnotations")
+#@ load("functions/kapp-annotations.lib.yaml", "addKappAnnotations", "keepOriginalOnVersioned")
 
 #@ orderedPackagesList = [
 #@    "cert-manager",
@@ -38,13 +38,13 @@
 #@     packagePath = "packages/" + name
 #@     packageValues = package.settings
 #@     if package.enabled:
---- #@ template.replace(overlay.apply(library.get(packagePath).with_data_values(packageValues).eval(), addKappAnnotations(name, overlayedValues, orderedPackagesList)))
+--- #@ template.replace(overlay.apply(library.get(packagePath).with_data_values(packageValues).eval(), addKappAnnotations(name, overlayedValues, orderedPackagesList), keepOriginalOnVersioned()))
 #@     end
 #@   end
 
 #@ allInfo = struct.make(config=data.values, values=overlayedValues)
 #@ if overlayedValues.clusterPackages["educates"].enabled:
---- #@ template.replace(overlay.apply(library.get("config").with_data_values(allInfo).eval(), addKappAnnotations("educates", overlayedValues, orderedPackagesList)))
+--- #@ template.replace(overlay.apply(library.get("config").with_data_values(allInfo).eval(), addKappAnnotations("educates", overlayedValues, orderedPackagesList), keepOriginalOnVersioned()))
 #@ else:
 --- #@ template.replace(overlay.apply(library.get("config").with_data_values(allInfo).eval()))
 #@ end

--- a/carvel-packages/installer/bundle/config/ytt/functions/kapp-annotations.lib.yaml
+++ b/carvel-packages/installer/bundle/config/ytt/functions/kapp-annotations.lib.yaml
@@ -47,3 +47,32 @@ metadata:
     kapp.k14s.io/change-rule.delete: #@ "delete after deleting educates-installer/{}".format(next)
     #@ end
 #@ end
+
+#! Versioned resources must keep the kapp.k14s.io/original annotation. Without
+#! it kapp diffs the rendered resource against live cluster state, and any
+#! deterministic server-side mutation (such as Secret stringData being
+#! converted to data) makes every deploy look like a change, minting a new
+#! version and rolling every consumer of the versioned name on each reconcile.
+#@ def isVersioned(index, left, right):
+#@   if "metadata" not in left:
+#@     return False
+#@   end
+#@   metadata = left["metadata"]
+#@   if not metadata or "annotations" not in metadata:
+#@     return False
+#@   end
+#@   annotations = metadata["annotations"]
+#@   if not annotations:
+#@     return False
+#@   end
+#@   return "kapp.k14s.io/versioned" in annotations
+#@ end
+
+#@ def keepOriginalOnVersioned():
+#@overlay/match by=isVersioned, expects="0+"
+---
+metadata:
+  annotations:
+    #@overlay/remove
+    kapp.k14s.io/disable-original:
+#@ end

--- a/project-docs/release-notes/version-3.8.0.md
+++ b/project-docs/release-notes/version-3.8.0.md
@@ -235,3 +235,22 @@ Bugs Fixed
   the time which has elapsed since the workshop session was allocated to the
   user when checking whether a workshop session should be deleted due to
   being orphaned or inactive.
+
+* Every reconcile of the installer created a new version of the
+  ``educates-config`` secret even when the rendered configuration was
+  identical to the previous version, causing a rolling restart of the
+  ``session-manager`` and ``secrets-manager`` operators on every reconcile.
+  This was because the secret is populated using ``stringData``, which the
+  Kubernetes API server converts to ``data`` on the live object, while the
+  ``kapp.k14s.io/original`` annotation was disabled for all resources, so
+  ``kapp`` compared the rendered resource against the live cluster state and
+  treated every deploy as a change to the versioned secret. Versioned
+  resources now retain the ``kapp.k14s.io/original`` annotation so that
+  unchanged deploys are recognised as unchanged, and a new secret version,
+  with the resulting restart of the operators, only occurs when the
+  configuration has actually changed. The ``azure-config-file`` secret used
+  by ``external-dns`` for Azure DNS suffered the same mismatch and is now
+  populated using ``data`` with explicit base64 encoding, and the
+  ``remote-access-token`` service account token secret is no longer
+  re-applied on every reconcile as the token contents populated by
+  Kubernetes are now preserved when calculating changes.


### PR DESCRIPTION
Fixes #1151

## Problem

Every reconcile of the installer created a new `educates-config-ver-N` secret
even when the rendered configuration was byte-for-byte identical to the
previous version. Because `session-manager` and `secrets-manager` mount that
secret by its versioned name, each new version was a real pod-template change
and both operators were rolled on every reconcile.

## Root cause

The secret is populated via `stringData`, which the API server converts to
`data` on the live object, and `kapp.k14s.io/disable-original` is applied to
every resource by the global annotations overlay. Without the
`kapp.k14s.io/original` annotation, kapp diffs the rendered resource
(`stringData`) against live cluster state (`data`), which can never match, so
every deploy looked like a change to the versioned secret.

Switching the secret to `data` with explicit base64 encoding is not viable:
the kbld search rules in `kbld/kbld-bundle.yaml` rewrite image references
inside `educates-operator-config.yaml` (digest pinning and air-gapped
relocation) and cannot see into base64 values. Worse, kbld's `yaml` update
strategy re-serializes the matched value with a leading `---` document
separator, which corrupts a base64 `data` value outright (`illegal base64
data at input byte 0`).

## Fix

* Versioned resources now retain the `kapp.k14s.io/original` annotation
  (new `keepOriginalOnVersioned` overlay applied after `addKappAnnotations`),
  so kapp compares against what it last applied and only mints a new version,
  and rolls the operators, when the configuration actually changed. The
  `original-diff-md5` mechanism absorbs the deterministic `stringData` to
  `data` server-side conversion.
* The `azure-config-file` secret used by `external-dns` for Azure DNS had
  the same `stringData` mismatch (benign, as it is not versioned, but it was
  re-applied on every reconcile). It carries no image references, so it is
  now populated via `data` with explicit base64 encoding.
* The previously commented-out kapp rebase rule for service-account token
  secrets is now enabled, so the `remote-access-token` secret is no longer
  re-applied on every reconcile (its `data` and service-account annotations
  are populated by the token controller and are now preserved when
  calculating changes).

## Validation

* kapp semantics verified in isolation on a kind cluster: a versioned
  `stringData` secret with `disable-original` mints a new version on every
  identical deploy; without it, repeated identical deploys keep `ver-1` and a
  genuine content change still mints `ver-2`.
* Full end-to-end test on a kind cluster via a kapp-controller `App`
  (the same install shape as the issue reporter): first reconcile deploys the
  platform with `educates-config-ver-1`; a second forced reconcile with
  unchanged values produces no new secret version and no restart of
  `session-manager` or `secrets-manager`.
* Verified kbld still resolves image references inside the rendered
  `educates-operator-config.yaml` to digest form.

Existing installs will see one final version bump and operator roll on their
first upgrade deploy (the `original` annotation gets stored at that point),
after which unchanged reconciles are quiet.
