### PR TITLE
fix(deps): update sqlparse to 0.6.0 in training-portal for CVE remediation (3.8 backport)

### DIFF
--- a/training-portal/uv.lock
+++ b/training-portal/uv.lock
@@ -799,11 +799,11 @@ wheels = [
 
 [[package]]
 name = "sqlparse"
-version = "0.5.5"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815, upload-time = "2025-12-19T07:17:45.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/d3/3f06a1006f2261d1342aefb3c71eed02f5d4ca5bdbecd86ebc12ad38306e/sqlparse-0.6.0.tar.gz", hash = "sha256:113c35c75365ab9cc9c7231d68c6428fb11c085fc8e9eb1ad659b7ddbf6cd2b9", size = 178477, upload-time = "2026-08-13T19:16:06.396Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138, upload-time = "2025-12-19T07:17:46.573Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/50/f00935da0ec7cbf325f8dc4f772ae46fbc7b672dd62876e73f0a94adda57/sqlparse-0.6.0-py3-none-any.whl", hash = "sha256:b861c0288ce2fa56209a9a6412d2e066ac664b3873b89c26c9d8415e8e32996f", size = 50070, upload-time = "2026-08-13T19:16:04.062Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Backport of #1156 to the 3.8 line ahead of the next release candidate:
`sqlparse` 0.5.5 to 0.6.0 in `training-portal/uv.lock`, fixing
`CVE-2026-71491`, `CVE-2026-59894`, `CVE-2026-59893` and `CVE-2026-54284`.
sqlparse is a transitive dependency of Django, so only the lock file moves;
the resulting package block is byte-identical to the one #1156 merged on
`develop`. The lock was regenerated with uv 0.11, the same version the
training-portal image builds with.

## Audit coverage

`pip-audit` was run against every Python dependency surface on this branch,
exporting each uv lock with `--no-dev` (the runtime closure that ships in
the images) and auditing the pinned requirements files directly:

| Project | Result |
|---|---|
| training-portal | sqlparse 0.5.5 (4 CVEs) — fixed by this PR |
| session-manager | clean |
| secrets-manager | clean |
| lookup-service | clean |
| tunnel-manager | clean |
| base-environment httpd `requirements.txt` | clean |
| project-docs `requirements.txt` | clean |

After the lock upgrade the training-portal audit reports no known
vulnerabilities, so this clears the last outstanding Python dependency
finding on the branch.
